### PR TITLE
Update External DNS version from 6.20.4 to 6.26.1

### DIFF
--- a/dns/external-dns/Chart.yaml
+++ b/dns/external-dns/Chart.yaml
@@ -4,5 +4,5 @@ version: 1.0.0
 description: This Chart deploys external-dns.
 dependencies:
   - name: external-dns
-    version: 6.20.4
+    version: 6.26.1
     repository: https://charts.bitnami.com/bitnami


### PR DESCRIPTION
	     _        __  __
	   _| |_   _ / _|/ _|  between old_values.yaml
	 / _' | | | | |_| |_       and new_values.yaml
	| (_| | |_| |  _|  _|
	 \__,_|\__, |_| |_|   returned six differences
	        |___/
	
	(root level)
	+ two map entries added:
	  ## @param ingressClassFilters Filter sources managed by external-dns via IngressClass (optional)
	  ##
	  ingressClassFilters: []
	  ## @param managedRecordTypesFilters Filter record types managed by external-dns (optional)
	  ##
	  managedRecordTypesFilters: []
	  
	
	
	image.tag
	  ± value change
	    - 0.13.4-debian-11-r19
	    + 0.13.6-debian-11-r11
	
	aws
	  + two map entries added:
	    ## @param aws.dynamodbTable When using the AWS provider, sets the DynamoDB table name to use for dynamodb registry
	    ## ref: https://github.com/kubernetes-sigs/external-dns/blob/0483ffde22e60436f16be154b9fe1a388a1400d0/docs/registry/dynamodb.md
	    ##
	    dynamodbTable: 
	    ## @param aws.dynamodbRegion When using the AWS provider, sets the DynamoDB table region to use for dynamodb registry
	    ## ref: https://github.com/kubernetes-sigs/external-dns/blob/0483ffde22e60436f16be154b9fe1a388a1400d0/docs/registry/dynamodb.md
	    ##
	    dynamodbRegion: 
	    
	  
	
	azure
	  + one map entry added:
	    ## @param azure.useWorkloadIdentityExtension When using the Azure provider, set if you use Workload Identity extension.
	    ##
	    useWorkloadIdentityExtension: false
	    
	  
	
	rfc2136.tsigKeyname
	  ± value change
	    - externaldns-key
	    + rfc2136_tsig_secret
	
	service
	  + one map entry added:
	    ## @param service.externalName Service external name
	    ##
	    externalName: