### PR TITLE
Update kyverno version from 2.5.3 to 3.0.5

### DIFF
--- a/kyverno.yaml
+++ b/kyverno.yaml
@@ -1,0 +1,73 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: HelmRepository
+metadata:
+  name: kyverno
+  namespace: kyverno
+spec:
+  interval: 1h0m0s
+  url: https://kyverno.github.io/kyverno/
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: kyverno
+  namespace: kyverno
+  labels:
+    app: kyverno
+    app.kubernetes.io/component: kyverno
+    app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/version: latest
+spec:
+  releaseName: kyverno
+  interval: 1h0m0s
+  chart:
+    spec:
+      chart: kyverno
+      version: 3.0.5
+      sourceRef:
+        kind: HelmRepository
+        name: kyverno
+  values:
+    podAnnotations:
+      ad.datadoghq.com/kyverno.check_names: '["openmetrics"]'
+      ad.datadoghq.com/kyverno.init_configs: '[{}]'
+      ad.datadoghq.com/kyverno.instances: '[{"prometheus_url": "http://kyverno-svc-metrics.kyverno.svc.cluster.local:8000/metrics","namespace": "kyverno","max_returned_metrics":"10000", "metrics": ["kyverno_policy_rule_info_total","kyverno_admission_requests", "kyverno_policy_changes", "kyverno_policy_results_total"]}]'
+    installCRDs: true
+    serviceMonitor:
+      enabled: true
+      additionalLabels:
+        release: kube-prometheus-stack
+    replicaCount: 3
+    hostNetwork: ${hostNetwork}
+    config:
+      webhooks:
+        - namespaceSelector:
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - twistlock
+    resources:
+      # -- Pod resource limits
+      limits:
+        memory: 2048Mi
+      # -- Pod resource requests
+      requests:
+        cpu: 1000m
+        memory: 512Mi
+    tolerations:
+      - key: "admin"
+        operator: "Exists"
+        effect: "NoExecute"
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - preference:
+            matchExpressions:
+              - key: cloud.google.com/gke-nodepool
+                operator: In
+                values:
+                  - admin
+          weight: 100
+    excludeKyvernoNamespace: true


### PR DESCRIPTION
A new chart update has been found!

Recommended image version: **v1.10.3**

Please **take a deep look onto compatibility matrix** for this app, **ensure the version match the cluster** and **update your values** before merging.


	     _        __  __
	   _| |_   _ / _|/ _|  between old_values.yaml
	 / _' | | | | |_| |_       and new_values.yaml
	| (_| | |_| |  _|  _|
	 \__,_|\__, |_| |_|   returned five differences
	        |___/
	
	(root level)
	- 38 map entries removed:
	  resources:
	    # -- Pod resource limits
	  limits:
	      memory: 384Mi
	    # -- Pod resource requests
	  requests:
	      cpu: 100m
	      memory: 128Mi
	  # - ResourceA
	  # - ResourceB
	  
	  # -- Exclude Kyverno namespace
	  # Determines if default Kyverno namespace exclusion is enabled for webhooks and resourceFilters
	  excludeKyvernoNamespace: true
	  # -- Whether to have Helm install the Kyverno CRDs.
	  # If the CRDs are not installed by Helm, they must be added before policies can be created.
	  installCRDs: true
	  # -- A writable volume to use for the TUF root initialization
	  tufRootMountPath: /.sigstore
	  # -- Change `hostNetwork` to `true` when you want the kyverno's pod to share its host's network namespace.
	  # Useful for situations like when you end up dealing with a custom CNI over Amazon EKS.
	  # Update the `dnsPolicy` accordingly as well to suit the host network mode.
	  hostNetwork: false
	  # -- `dnsPolicy` determines the manner in which DNS resolution happens in the cluster.
	  # In case of `hostNetwork: true`, usually, the `dnsPolicy` is suitable to be `ClusterFirstWithHostNet`.
	  # For further reference: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy.
	  dnsPolicy: ClusterFirst
	  # -- (int) Desired number of pods
	  replicaCount: ~
	  # -- Additional labels to add to each pod
	  podLabels: {}
	  # example.com/label: foo
	  # -- Additional annotations to add to each pod
	  podAnnotations: {}
	  # example.com/annotation: foo
	  # -- Security context for the pod
	  podSecurityContext: {}
	  # -- Env variables for containers.
	  envVars: {}
	  # -- Optional priority class to be used for kyverno pods
	  priorityClassName: 
	  # -- Kyverno requires a certificate key pair and corresponding certificate authority
	  # to properly register its webhooks. This can be done in one of 3 ways:
	  # 1) Use kube-controller-manager to generate a CA-signed certificate (preferred)
	  # 2) Provide your own CA and cert.
	  #    In this case, you will need to create a certificate with a specific name and data structure.
	  #    As long as you follow the naming scheme, it will be automatically picked up.
	  #    kyverno-svc.(namespace).svc.kyverno-tls-ca (with data entry named rootCA.crt)
	  #    kyverno-svc.kyverno.svc.kyverno-tls-pair (with data entries named tls.key and tls.crt)
	  # 3) Let Helm generate a self signed cert, by setting createSelfSignedCert true
	  # If letting Kyverno create its own CA or providing your own, make createSelfSignedCert is false
	  createSelfSignedCert: false
	  # -- Topology spread constraints.
	  topologySpreadConstraints: []
	  # -- Pod affinity constraints.
	  podAffinity: {}
	  # -- Node affinity constraints.
	  nodeAffinity: {}
	  # -- Namespace the chart deploys to
	  namespace: 
	  # -- Node labels for pod assignment
	  nodeSelector: {}
	  # -- List of node taints to tolerate
	  tolerations: []
	  # TODO(mbarrien): Should we just list all resources for the
	  # generatecontroller in here rather than having defaults hard-coded?
	  generatecontrollerExtraResources: 
	  # -- Env variables for initContainers.
	  envVarsInit: {}
	  networkPolicy:
	    # -- When true, use a NetworkPolicy to allow ingress to the webhook
	  # This is useful on clusters using Calico and/or native k8s network policies in a default-deny setup.
	  enabled: false
	    # -- A list of valid from selectors according to https://kubernetes.io/docs/concepts/services-networking/network-policies.
	  ingressFrom: []
	  antiAffinity:
	    # -- Pod antiAffinities toggle.
	  # Enabled by default but can be disabled if you want to schedule pods to the same node.
	  enable: true
	  # -- Extra arguments to give to the binary.
	  extraArgs:
	  - --autogenInternals=false
	  image:
	    # -- Image repository
	  repository: ghcr.io/kyverno/kyverno
	    # -- Image tag
	  # Defaults to appVersion in Chart.yaml if omitted
	  tag: 
	    # -- Image pull policy
	  pullPolicy: IfNotPresent
	    # -- Image pull secrets
	  pullSecrets: []
	  # - secretName
	  testImage:
	    # -- Image repository
	  # Defaults to `busybox` if omitted
	  repository: 
	    # -- Image tag
	  # Defaults to `latest` if omitted
	  tag: 
	    # -- Image pull policy
	  # Defaults to image.pullPolicy if omitted
	  pullPolicy: 
	  serviceMonitor:
	    # -- Create a `ServiceMonitor` to collect Prometheus metrics.
	  enabled: false
	    # -- Additional labels
	  additionalLabels: 
	    # key: value
	  # -- Override namespace (default is the same as kyverno)
	  namespace: 
	    # --  Interval to scrape metrics
	  interval: 30s
	    # -- Timeout if metrics can't be retrieved in given time interval
	  scrapeTimeout: 25s
	    # -- Is TLS required for endpoint
	  secure: false
	    # -- TLS Configuration for endpoint
	  tlsConfig: {}
	  initImage:
	    # -- Image repository
	  repository: ghcr.io/kyverno/kyvernopre
	    # -- Image tag
	  # If initImage.tag is missing, defaults to image.tag
	  tag: 
	    # -- Image pull policy
	  # If initImage.pullPolicy is missing, defaults to image.pullPolicy
	  pullPolicy: 
	  podDisruptionBudget:
	    # -- Configures the minimum available pods for kyverno disruptions.
	  # Cannot be used if `maxUnavailable` is set.
	  minAvailable: 1
	    # -- Configures the maximum unavailable pods for kyverno disruptions.
	  # Cannot be used if `minAvailable` is set.
	  maxUnavailable: 
	  metricsService:
	    # -- Service type.
	  type: ClusterIP
	    # -- Create service.
	  create: true
	    # -- Service port.
	  # Kyverno's metrics server will be exposed at this port.
	  port: 8000
	    # -- Service node port.
	  # Only used if `metricsService.type` is `NodePort`.
	  nodePort: 
	    # -- Service annotations.
	  annotations: {}
	  service:
	    # -- Service type.
	  type: ClusterIP
	    # -- Service port.
	  port: 443
	    # -- Service node port.
	  # Only used if `service.type` is `NodePort`.
	  nodePort: 
	    # -- Service annotations.
	  annotations: {}
	  # -- Deployment update strategy.
	  # Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
	  # @default -- See [values.yaml](values.yaml)
	  updateStrategy:
	    type: RollingUpdate
	    rollingUpdate:
	      maxSurge: 1
	      maxUnavailable: 40%!(NOVERB)
	  # -- Readiness Probe.
	  # The block is directly forwarded into the deployment, so you can use whatever readinessProbe configuration you want.
	  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
	  # @default -- See [values.yaml](values.yaml)
	  readinessProbe:
	    httpGet:
	      path: /health/readiness
	      port: 9443
	      scheme: HTTPS
	    initialDelaySeconds: 5
	    periodSeconds: 10
	    timeoutSeconds: 5
	    failureThreshold: 6
	    successThreshold: 1
	  rbac:
	    # -- Create ClusterRoles, ClusterRoleBindings, and ServiceAccount
	  create: true
	    serviceAccount:
	      # -- The ServiceAccount name
	  name: 
	      # -- Create a ServiceAccount
	  create: true
	      # -- Annotations for the ServiceAccount
	  annotations: {}
	  # example.com/annotation: value
	  # -- Liveness probe.
	  # The block is directly forwarded into the deployment, so you can use whatever livenessProbe configuration you want.
	  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
	  # @default -- See [values.yaml](values.yaml)
	  livenessProbe:
	    httpGet:
	      path: /health/liveness
	      port: 9443
	      scheme: HTTPS
	    initialDelaySeconds: 15
	    periodSeconds: 30
	    timeoutSeconds: 5
	    failureThreshold: 2
	    successThreshold: 1
	  initResources:
	    # -- Pod resource limits
	  limits:
	      cpu: 100m
	      memory: 256Mi
	    # -- Pod resource requests
	  requests:
	      cpu: 10m
	      memory: 64Mi
	  # -- Security context for the containers
	  securityContext:
	    runAsNonRoot: true
	    privileged: false
	    allowPrivilegeEscalation: false
	    readOnlyRootFilesystem: true
	    capabilities:
	      drop:
	      - ALL
	    seccompProfile:
	      type: RuntimeDefault
	  # -- Pod anti affinity constraints.
	  # @default -- See [values.yaml](values.yaml)
	  podAntiAffinity:
	    preferredDuringSchedulingIgnoredDuringExecution:
	    - weight: 1
	      podAffinityTerm:
	        labelSelector:
	          matchExpressions:
	          - key: app.kubernetes.io/name
	            operator: In
	            values:
	            - kyverno
	        topologyKey: kubernetes.io/hostname
	  
	
	+ 15 map entries added:
	  # -- Internal settings used with `helm template` to generate install manifest
	  # @ignored
	  templating:
	    version: ~
	    enabled: false
	    debug: false
	  # -- (string) Override the namespace the chart deploys to
	  namespaceOverride: ~
	  upgrade:
	    # -- Upgrading from v2 to v3 is not allowed by default, set this to true once changes have been reviewed.
	  fromV2: false
	  apiVersionOverride:
	    # -- (string) Override api version used to create `PodDisruptionBudget`` resources.
	  # When not specified the chart will check if `policy/v1/PodDisruptionBudget` is available to
	  # determine the api version automatically.
	  podDisruptionBudget: ~
	  # CRDs configuration
	  crds:
	    # -- Whether to have Helm install the Kyverno CRDs, if the CRDs are not installed by Helm, they must be added before policies can be created
	  install: true
	    # -- Additional CRDs annotations
	  annotations: {}
	  # argocd.argoproj.io/sync-options: Replace=true
	  # strategy.spinnaker.io/replace: 'true'
	  # Metrics configuration
	  metricsConfig:
	    # -- (string) The configmap name (required if `create` is `false`).
	  name: ~
	    # -- Create the configmap.
	  create: true
	    # -- Additional annotations to add to the configmap.
	  annotations: {}
	    namespaces:
	      # -- List of namespaces to capture metrics for.
	  include: []
	      # -- list of namespaces to NOT capture metrics for.
	  exclude: []
	    # -- (string) Rate at which metrics should reset so as to clean up the memory footprint of kyverno metrics, if you might be expecting high memory footprint of Kyverno's metrics. Default: 0, no refresh of metrics
	  metricsRefreshInterval: ~
	  # metricsRefreshInterval: 24h
	  # -- Existing Image pull secrets for image verification policies, this will define the `--imagePullSecrets` argument
	  existingImagePullSecrets: []
	  # - test-registry
	  # - other-test-registry
	  # Tests configuration
	  test:
	    resources:
	      # -- Pod resource limits
	  limits:
	        cpu: 100m
	        memory: 256Mi
	      # -- Pod resource requests
	  requests:
	        cpu: 10m
	        memory: 64Mi
	    image:
	      # -- (string) Image registry
	  registry: ~
	      # -- Image repository
	  repository: busybox
	      # -- Image tag
	  # Defaults to `latest` if omitted
	  tag: 1.35
	      # -- (string) Image pull policy
	  # Defaults to image.pullPolicy if omitted
	  pullPolicy: ~
	    # -- Security context for the test containers
	  securityContext:
	      runAsUser: 65534
	      runAsGroup: 65534
	      runAsNonRoot: true
	      privileged: false
	      allowPrivilegeEscalation: false
	      readOnlyRootFilesystem: true
	      capabilities:
	        drop:
	        - ALL
	      seccompProfile:
	        type: RuntimeDefault
	  grafana:
	    # -- Enable grafana dashboard creation.
	  enabled: false
	    # -- Configmap name template.
	  configMapName: "{{ include "kyverno.fullname" . }}-grafana"
	    # -- (string) Namespace to create the grafana dashboard configmap.
	  # If not set, it will be created in the same namespace where the chart is deployed.
	  namespace: ~
	    # -- Grafana dashboard configmap annotations.
	  annotations: {}
	    # -- Grafana dashboard configmap labels
	  labels:
	      grafana_dashboard: 1
	  # Features configuration
	  features:
	    admissionReports:
	      # -- Enables the feature
	  enabled: true
	    policyReports:
	      # -- Enables the feature
	  enabled: true
	    autoUpdateWebhooks:
	      # -- Enables the feature
	  enabled: true
	    backgroundScan:
	      # -- Enables the feature
	  enabled: true
	      # -- Number of background scan workers
	  backgroundScanWorkers: 2
	      # -- Background scan interval
	  backgroundScanInterval: 1h
	      # -- Skips resource filters in background scan
	  skipResourceFilters: true
	    configMapCaching:
	      # -- Enables the feature
	  enabled: true
	    deferredLoading:
	      # -- Enables the feature
	  enabled: true
	    dumpPayload:
	      # -- Enables the feature
	  enabled: false
	    forceFailurePolicyIgnore:
	      # -- Enables the feature
	  enabled: false
	    logging:
	      # -- Logging format
	  format: text
	      # -- Logging verbosity
	  verbosity: 2
	    omitEvents:
	      # -- Events which should not be emitted (possible values `PolicyViolation`, `PolicyApplied`, `PolicyError`, and `PolicySkipped`)
	  eventTypes: []
	  # - PolicyViolation
	  # - PolicyApplied
	  # - PolicyError
	  # - PolicySkipped
	    policyExceptions:
	      # -- Enables the feature
	  enabled: false
	      # -- Restrict policy exceptions to a single namespace
	  namespace: 
	    protectManagedResources:
	      # -- Enables the feature
	  enabled: false
	    registryClient:
	      # -- Allow insecure registry
	  allowInsecure: false
	      # -- Enable registry client helpers
	  credentialHelpers:
	      - default
	      - google
	      - amazon
	      - azure
	      - github
	    reports:
	      # -- Reports chunk size
	  chunkSize: 1000
	  # Cleanup cronjobs to prevent internal resources from stacking up in the cluster
	  cleanupJobs:
	    admissionReports:
	      # -- Job resources
	  resources: {}
	      # -- Security context for the pod
	  podSecurityContext: {}
	      # -- List of node taints to tolerate
	  tolerations: []
	      # -- Image pull secrets
	  imagePullSecrets: []
	  # - name: secretName
	      # -- Cronjob schedule
	  schedule: "*/10 * * * *"
	      # -- Reports threshold, if number of reports are above this value the cronjob will start deleting them
	  threshold: 10000
	      # -- Node affinity constraints.
	  nodeAffinity: {}
	      # -- Pod affinity constraints.
	  podAffinity: {}
	      # -- Pod anti affinity constraints.
	  podAntiAffinity: {}
	      # -- Enable cleanup cronjob
	  enabled: true
	      # -- Node labels for pod assignment
	  nodeSelector: {}
	      # -- Pod Annotations
	  podAnnotations: {}
	      # -- Pod labels
	  podLabels: {}
	      image:
	        # -- (string) Image registry
	  registry: ~
	        # -- Image repository
	  repository: bitnami/kubectl
	        # -- Image tag
	  # Defaults to `latest` if omitted
	  tag: 1.26.4
	        # -- (string) Image pull policy
	  # Defaults to image.pullPolicy if omitted
	  pullPolicy: ~
	      # -- Cronjob history
	  history:
	        success: 1
	        failure: 1
	      # -- Security context for the containers
	  securityContext:
	        runAsNonRoot: true
	        privileged: false
	        allowPrivilegeEscalation: false
	        readOnlyRootFilesystem: true
	        capabilities:
	          drop:
	          - ALL
	        seccompProfile:
	          type: RuntimeDefault
	    clusterAdmissionReports:
	      # -- Job resources
	  resources: {}
	      # -- Security context for the pod
	  podSecurityContext: {}
	      # -- List of node taints to tolerate
	  tolerations: []
	      # -- Image pull secrets
	  imagePullSecrets: []
	  # - name: secretName
	      # -- Cronjob schedule
	  schedule: "*/10 * * * *"
	      # -- Reports threshold, if number of reports are above this value the cronjob will start deleting them
	  threshold: 10000
	      # -- Node affinity constraints.
	  nodeAffinity: {}
	      # -- Pod affinity constraints.
	  podAffinity: {}
	      # -- Pod anti affinity constraints.
	  podAntiAffinity: {}
	      # -- Enable cleanup cronjob
	  enabled: true
	      # -- Node labels for pod assignment
	  nodeSelector: {}
	      # -- Pod Annotations
	  podAnnotations: {}
	      # -- Pod Labels
	  podLabels: {}
	      image:
	        # -- (string) Image registry
	  registry: ~
	        # -- Image repository
	  repository: bitnami/kubectl
	        # -- Image tag
	  # Defaults to `latest` if omitted
	  tag: 1.26.4
	        # -- (string) Image pull policy
	  # Defaults to image.pullPolicy if omitted
	  pullPolicy: ~
	      # -- Cronjob history
	  history:
	        success: 1
	        failure: 1
	      # -- Security context for the containers
	  securityContext:
	        runAsNonRoot: true
	        privileged: false
	        allowPrivilegeEscalation: false
	        readOnlyRootFilesystem: true
	        capabilities:
	          drop:
	          - ALL
	        seccompProfile:
	          type: RuntimeDefault
	  # Admission controller configuration
	  admissionController:
	    # -- Overrides features defined at the root level
	  featuresOverride: {}
	    rbac:
	      # -- Create RBAC resources
	  create: true
	      serviceAccount:
	        # -- The ServiceAccount name
	  name: 
	        # -- Annotations for the ServiceAccount
	  annotations: {}
	  # example.com/annotation: value
	      clusterRole:
	        # -- Extra resource permissions to add in the cluster role
	  extraResources: []
	  # - apiGroups:
	  #     - ''
	  #   resources:
	  #     - pods
	  #   verbs:
	  #     - create
	  #     - update
	  #     - delete
	    # -- Create self-signed certificates at deployment time.
	  # The certificates won't be automatically renewed if this is set to `true`.
	  createSelfSignedCert: false
	    # -- (int) Desired number of pods
	  replicas: ~
	    # -- Additional labels to add to each pod
	  podLabels: {}
	  # example.com/label: foo
	    # -- Additional annotations to add to each pod
	  podAnnotations: {}
	  # example.com/annotation: foo
	    # -- Deployment update strategy.
	  # Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
	  # @default -- See [values.yaml](values.yaml)
	  updateStrategy:
	      type: RollingUpdate
	      rollingUpdate:
	        maxSurge: 1
	        maxUnavailable: 40%!(NOVERB)
	    # -- Optional priority class
	  priorityClassName: 
	    # -- Change `hostNetwork` to `true` when you want the pod to share its host's network namespace.
	  # Useful for situations like when you end up dealing with a custom CNI over Amazon EKS.
	  # Update the `dnsPolicy` accordingly as well to suit the host network mode.
	  hostNetwork: false
	    # -- `dnsPolicy` determines the manner in which DNS resolution happens in the cluster.
	  # In case of `hostNetwork: true`, usually, the `dnsPolicy` is suitable to be `ClusterFirstWithHostNet`.
	  # For further reference: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy.
	  dnsPolicy: ClusterFirst
	    # -- Startup probe.
	  # The block is directly forwarded into the deployment, so you can use whatever startupProbes configuration you want.
	  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
	  # @default -- See [values.yaml](values.yaml)
	  startupProbe:
	      httpGet:
	        path: /health/liveness
	        port: 9443
	        scheme: HTTPS
	      failureThreshold: 20
	      initialDelaySeconds: 2
	      periodSeconds: 6
	    # -- Liveness probe.
	  # The block is directly forwarded into the deployment, so you can use whatever livenessProbe configuration you want.
	  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
	  # @default -- See [values.yaml](values.yaml)
	  livenessProbe:
	      httpGet:
	        path: /health/liveness
	        port: 9443
	        scheme: HTTPS
	      initialDelaySeconds: 15
	      periodSeconds: 30
	      timeoutSeconds: 5
	      failureThreshold: 2
	      successThreshold: 1
	    # -- Readiness Probe.
	  # The block is directly forwarded into the deployment, so you can use whatever readinessProbe configuration you want.
	  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
	  # @default -- See [values.yaml](values.yaml)
	  readinessProbe:
	      httpGet:
	        path: /health/readiness
	        port: 9443
	        scheme: HTTPS
	      initialDelaySeconds: 5
	      periodSeconds: 10
	      timeoutSeconds: 5
	      failureThreshold: 6
	      successThreshold: 1
	    # -- Node labels for pod assignment
	  nodeSelector: {}
	    # -- List of node taints to tolerate
	  tolerations: []
	    antiAffinity:
	      # -- Pod antiAffinities toggle.
	  # Enabled by default but can be disabled if you want to schedule pods to the same node.
	  enabled: true
	    # -- Pod anti affinity constraints.
	  # @default -- See [values.yaml](values.yaml)
	  podAntiAffinity:
	      preferredDuringSchedulingIgnoredDuringExecution:
	      - weight: 1
	        podAffinityTerm:
	          labelSelector:
	            matchExpressions:
	            - key: app.kubernetes.io/component
	              operator: In
	              values:
	              - admission-controller
	          topologyKey: kubernetes.io/hostname
	    # -- Pod affinity constraints.
	  podAffinity: {}
	    # -- Node affinity constraints.
	  nodeAffinity: {}
	    # -- Topology spread constraints.
	  topologySpreadConstraints: []
	    # -- Security context for the pod
	  podSecurityContext: {}
	    podDisruptionBudget:
	      # -- Configures the minimum available pods for disruptions.
	  # Cannot be used if `maxUnavailable` is set.
	  minAvailable: 1
	      # -- Configures the maximum unavailable pods for disruptions.
	  # Cannot be used if `minAvailable` is set.
	  maxUnavailable: 
	    # -- A writable volume to use for the TUF root initialization.
	  tufRootMountPath: /.sigstore
	    # -- Volume to be mounted in pods for TUF/cosign work.
	  sigstoreVolume:
	      emptyDir: {}
	    # -- Image pull secrets
	  imagePullSecrets: []
	  # - secretName
	    initContainer:
	      resources:
	        # -- Pod resource limits
	  limits:
	          cpu: 100m
	          memory: 256Mi
	        # -- Pod resource requests
	  requests:
	          cpu: 10m
	          memory: 64Mi
	      # -- Additional container args.
	  extraArgs: {}
	      # -- Additional container environment variables.
	  extraEnvVars: []
	      image:
	        # -- Image registry
	  registry: ghcr.io
	        # -- Image repository
	  repository: kyverno/kyvernopre
	        # -- (string) Image tag
	  # If missing, defaults to image.tag
	  tag: ~
	        # -- (string) Image pull policy
	  # If missing, defaults to image.pullPolicy
	  pullPolicy: ~
	      # -- Container security context
	  securityContext:
	        runAsNonRoot: true
	        privileged: false
	        allowPrivilegeEscalation: false
	        readOnlyRootFilesystem: true
	        capabilities:
	          drop:
	          - ALL
	        seccompProfile:
	          type: RuntimeDefault
	    container:
	      resources:
	        # -- Pod resource limits
	  limits:
	          memory: 384Mi
	        # -- Pod resource requests
	  requests:
	          cpu: 100m
	          memory: 128Mi
	      # -- Additional container args.
	  extraArgs: {}
	      # -- Additional container environment variables.
	  extraEnvVars: []
	      image:
	        # -- Image registry
	  registry: ghcr.io
	        # -- Image repository
	  repository: kyverno/kyverno
	        # -- (string) Image tag
	  # Defaults to appVersion in Chart.yaml if omitted
	  tag: ~
	        # -- Image pull policy
	  pullPolicy: IfNotPresent
	      # -- Container security context
	  securityContext:
	        runAsNonRoot: true
	        privileged: false
	        allowPrivilegeEscalation: false
	        readOnlyRootFilesystem: true
	        capabilities:
	          drop:
	          - ALL
	        seccompProfile:
	          type: RuntimeDefault
	    # -- Array of extra init containers
	  extraInitContainers: []
	  # - name: init-container
	  #   image: busybox
	  #   command: ['sh', '-c', 'echo Hello']
	    # -- Array of extra containers to run alongside kyverno
	  extraContainers: []
	  # - name: myapp-container
	  #   image: busybox
	  #   command: ['sh', '-c', 'echo Hello && sleep 3600']
	    service:
	      # -- Service type.
	  type: ClusterIP
	      # -- Service port.
	  port: 443
	      # -- Service node port.
	  # Only used if `type` is `NodePort`.
	  nodePort: 
	      # -- Service annotations.
	  annotations: {}
	    metricsService:
	      # -- Service type.
	  type: ClusterIP
	      # -- Create service.
	  create: true
	      # -- Service port.
	  # Kyverno's metrics server will be exposed at this port.
	  port: 8000
	      # -- Service node port.
	  # Only used if `type` is `NodePort`.
	  nodePort: 
	      # -- Service annotations.
	  annotations: {}
	    networkPolicy:
	      # -- When true, use a NetworkPolicy to allow ingress to the webhook
	  # This is useful on clusters using Calico and/or native k8s network policies in a default-deny setup.
	  enabled: false
	      # -- A list of valid from selectors according to https://kubernetes.io/docs/concepts/services-networking/network-policies.
	  ingressFrom: []
	    serviceMonitor:
	      # -- Create a `ServiceMonitor` to collect Prometheus metrics.
	  enabled: false
	      # -- Additional labels
	  additionalLabels: {}
	      # -- (string) Override namespace
	  namespace: ~
	      # --  Interval to scrape metrics
	  interval: 30s
	      # -- Timeout if metrics can't be retrieved in given time interval
	  scrapeTimeout: 25s
	      # -- Is TLS required for endpoint
	  secure: false
	      # -- TLS Configuration for endpoint
	  tlsConfig: {}
	      # -- RelabelConfigs to apply to samples before scraping
	  relabelings: []
	      # -- MetricRelabelConfigs to apply to samples before ingestion.
	  metricRelabelings: []
	    tracing:
	      # -- Enable tracing
	  enabled: false
	      # -- Traces receiver address
	  address: 
	      # -- Traces receiver port
	  port: 
	      # -- Traces receiver credentials
	  creds: 
	    metering:
	      # -- Disable metrics export
	  disabled: false
	      # -- Otel configuration, can be `prometheus` or `grpc`
	  config: prometheus
	      # -- Prometheus endpoint port
	  port: 8000
	      # -- Otel collector endpoint
	  collector: 
	      # -- Otel collector credentials
	  creds: 
	  # Background controller configuration
	  backgroundController:
	    resources:
	      # -- Pod resource limits
	  limits:
	        memory: 128Mi
	      # -- Pod resource requests
	  requests:
	        cpu: 100m
	        memory: 64Mi
	    # -- Node labels for pod assignment
	  nodeSelector: {}
	    # -- Additional container environment variables.
	  extraEnvVars: []
	    # -- Overrides features defined at the root level
	  featuresOverride: {}
	    # -- Security context for the pod
	  podSecurityContext: {}
	    # -- List of node taints to tolerate
	  tolerations: []
	    # -- (int) Desired number of pods
	  replicas: ~
	    # -- Additional labels to add to each pod
	  podLabels: {}
	  # example.com/label: foo
	    # -- Additional annotations to add to each pod
	  podAnnotations: {}
	  # example.com/annotation: foo
	    # -- Enable background controller.
	  enabled: true
	    # -- Optional priority class
	  priorityClassName: 
	    # -- Change `hostNetwork` to `true` when you want the pod to share its host's network namespace.
	  # Useful for situations like when you end up dealing with a custom CNI over Amazon EKS.
	  # Update the `dnsPolicy` accordingly as well to suit the host network mode.
	  hostNetwork: false
	    # -- Topology spread constraints.
	  topologySpreadConstraints: []
	    # -- Extra arguments passed to the container on the command line
	  extraArgs: {}
	    # -- Node affinity constraints.
	  nodeAffinity: {}
	    # -- Pod affinity constraints.
	  podAffinity: {}
	    # -- Image pull secrets
	  imagePullSecrets: []
	  # - secretName
	    # -- `dnsPolicy` determines the manner in which DNS resolution happens in the cluster.
	  # In case of `hostNetwork: true`, usually, the `dnsPolicy` is suitable to be `ClusterFirstWithHostNet`.
	  # For further reference: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy.
	  dnsPolicy: ClusterFirst
	    tracing:
	      # -- Enable tracing
	  enabled: false
	      # -- Traces receiver address
	  address: 
	      # -- Traces receiver port
	  port: 
	      # -- Traces receiver credentials
	  creds: 
	    metering:
	      # -- Disable metrics export
	  disabled: false
	      # -- Otel configuration, can be `prometheus` or `grpc`
	  config: prometheus
	      # -- Prometheus endpoint port
	  port: 8000
	      # -- Otel collector endpoint
	  collector: 
	      # -- Otel collector credentials
	  creds: 
	    networkPolicy:
	      # -- When true, use a NetworkPolicy to allow ingress to the webhook
	  # This is useful on clusters using Calico and/or native k8s network policies in a default-deny setup.
	  enabled: false
	      # -- A list of valid from selectors according to https://kubernetes.io/docs/concepts/services-networking/network-policies.
	  ingressFrom: []
	    antiAffinity:
	      # -- Pod antiAffinities toggle.
	  # Enabled by default but can be disabled if you want to schedule pods to the same node.
	  enabled: true
	    image:
	      # -- Image registry
	  registry: ghcr.io
	      # -- Image repository
	  repository: kyverno/background-controller
	      # -- Image tag
	  # Defaults to appVersion in Chart.yaml if omitted
	  tag: 
	      # -- Image pull policy
	  pullPolicy: IfNotPresent
	    serviceMonitor:
	      # -- Create a `ServiceMonitor` to collect Prometheus metrics.
	  enabled: false
	      # -- Additional labels
	  additionalLabels: {}
	      # -- (string) Override namespace
	  namespace: ~
	      # --  Interval to scrape metrics
	  interval: 30s
	      # -- Timeout if metrics can't be retrieved in given time interval
	  scrapeTimeout: 25s
	      # -- Is TLS required for endpoint
	  secure: false
	      # -- TLS Configuration for endpoint
	  tlsConfig: {}
	      # -- RelabelConfigs to apply to samples before scraping
	  relabelings: []
	      # -- MetricRelabelConfigs to apply to samples before ingestion.
	  metricRelabelings: []
	    podDisruptionBudget:
	      # -- Configures the minimum available pods for disruptions.
	  # Cannot be used if `maxUnavailable` is set.
	  minAvailable: 1
	      # -- Configures the maximum unavailable pods for disruptions.
	  # Cannot be used if `minAvailable` is set.
	  maxUnavailable: 
	    metricsService:
	      # -- Service type.
	  type: ClusterIP
	      # -- Create service.
	  create: true
	      # -- Service port.
	  # Metrics server will be exposed at this port.
	  port: 8000
	      # -- Service node port.
	  # Only used if `metricsService.type` is `NodePort`.
	  nodePort: 
	      # -- Service annotations.
	  annotations: {}
	    # -- Deployment update strategy.
	  # Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
	  # @default -- See [values.yaml](values.yaml)
	  updateStrategy:
	      type: RollingUpdate
	      rollingUpdate:
	        maxSurge: 1
	        maxUnavailable: 40%!(NOVERB)
	    rbac:
	      # -- Create RBAC resources
	  create: true
	      serviceAccount:
	        # -- Service account name
	  name: 
	        # -- Annotations for the ServiceAccount
	  annotations: {}
	  # example.com/annotation: value
	      clusterRole:
	        # -- Extra resource permissions to add in the cluster role
	  extraResources: []
	  # - apiGroups:
	  #     - ''
	  #   resources:
	  #     - pods
	  #   verbs:
	  #     - create
	  #     - update
	  #     - delete
	  #     - patch
	    # -- Security context for the containers
	  securityContext:
	      runAsNonRoot: true
	      privileged: false
	      allowPrivilegeEscalation: false
	      readOnlyRootFilesystem: true
	      capabilities:
	        drop:
	        - ALL
	      seccompProfile:
	        type: RuntimeDefault
	    # -- Pod anti affinity constraints.
	  # @default -- See [values.yaml](values.yaml)
	  podAntiAffinity:
	      preferredDuringSchedulingIgnoredDuringExecution:
	      - weight: 1
	        podAffinityTerm:
	          labelSelector:
	            matchExpressions:
	            - key: app.kubernetes.io/component
	              operator: In
	              values:
	              - background-controller
	          topologyKey: kubernetes.io/hostname
	  # Cleanup controller configuration
	  cleanupController:
	    resources:
	      # -- Pod resource limits
	  limits:
	        memory: 128Mi
	      # -- Pod resource requests
	  requests:
	        cpu: 100m
	        memory: 64Mi
	    # -- Topology spread constraints.
	  topologySpreadConstraints: []
	    # -- Additional labels to add to each pod
	  podLabels: {}
	  # example.com/label: foo
	    # -- Security context for the pod
	  podSecurityContext: {}
	    # -- Create self-signed certificates at deployment time.
	  # The certificates won't be automatically renewed if this is set to `true`.
	  createSelfSignedCert: false
	    # -- Overrides features defined at the root level
	  featuresOverride: {}
	    # -- Image pull secrets
	  imagePullSecrets: []
	  # - secretName
	    # -- (int) Desired number of pods
	  replicas: ~
	    # -- Node affinity constraints.
	  nodeAffinity: {}
	    # -- Additional annotations to add to each pod
	  podAnnotations: {}
	  # example.com/annotation: foo
	    # -- Node labels for pod assignment
	  nodeSelector: {}
	    # -- Optional priority class
	  priorityClassName: 
	    # -- Change `hostNetwork` to `true` when you want the pod to share its host's network namespace.
	  # Useful for situations like when you end up dealing with a custom CNI over Amazon EKS.
	  # Update the `dnsPolicy` accordingly as well to suit the host network mode.
	  hostNetwork: false
	    # -- `dnsPolicy` determines the manner in which DNS resolution happens in the cluster.
	  # In case of `hostNetwork: true`, usually, the `dnsPolicy` is suitable to be `ClusterFirstWithHostNet`.
	  # For further reference: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy.
	  dnsPolicy: ClusterFirst
	    # -- Extra arguments passed to the container on the command line
	  extraArgs: {}
	    # -- Additional container environment variables.
	  extraEnvVars: []
	    # -- Pod affinity constraints.
	  podAffinity: {}
	    # -- List of node taints to tolerate
	  tolerations: []
	    # -- Enable cleanup controller.
	  enabled: true
	    service:
	      # -- Service type.
	  type: ClusterIP
	      # -- Service port.
	  port: 443
	      # -- Service node port.
	  # Only used if `service.type` is `NodePort`.
	  nodePort: 
	      # -- Service annotations.
	  annotations: {}
	    metering:
	      # -- Disable metrics export
	  disabled: false
	      # -- Otel configuration, can be `prometheus` or `grpc`
	  config: prometheus
	      # -- Prometheus endpoint port
	  port: 8000
	      # -- Otel collector endpoint
	  collector: 
	      # -- Otel collector credentials
	  creds: 
	    antiAffinity:
	      # -- Pod antiAffinities toggle.
	  # Enabled by default but can be disabled if you want to schedule pods to the same node.
	  enabled: true
	    tracing:
	      # -- Enable tracing
	  enabled: false
	      # -- Traces receiver address
	  address: 
	      # -- Traces receiver port
	  port: 
	      # -- Traces receiver credentials
	  creds: 
	    serviceMonitor:
	      # -- Create a `ServiceMonitor` to collect Prometheus metrics.
	  enabled: false
	      # -- Additional labels
	  additionalLabels: {}
	      # -- (string) Override namespace
	  namespace: ~
	      # --  Interval to scrape metrics
	  interval: 30s
	      # -- Timeout if metrics can't be retrieved in given time interval
	  scrapeTimeout: 25s
	      # -- Is TLS required for endpoint
	  secure: false
	      # -- TLS Configuration for endpoint
	  tlsConfig: {}
	      # -- RelabelConfigs to apply to samples before scraping
	  relabelings: []
	      # -- MetricRelabelConfigs to apply to samples before ingestion.
	  metricRelabelings: []
	    networkPolicy:
	      # -- When true, use a NetworkPolicy to allow ingress to the webhook
	  # This is useful on clusters using Calico and/or native k8s network policies in a default-deny setup.
	  enabled: false
	      # -- A list of valid from selectors according to https://kubernetes.io/docs/concepts/services-networking/network-policies.
	  ingressFrom: []
	    podDisruptionBudget:
	      # -- Configures the minimum available pods for disruptions.
	  # Cannot be used if `maxUnavailable` is set.
	  minAvailable: 1
	      # -- Configures the maximum unavailable pods for disruptions.
	  # Cannot be used if `minAvailable` is set.
	  maxUnavailable: 
	    image:
	      # -- Image registry
	  registry: ghcr.io
	      # -- Image repository
	  repository: kyverno/cleanup-controller
	      # -- (string) Image tag
	  # Defaults to appVersion in Chart.yaml if omitted
	  tag: ~
	      # -- Image pull policy
	  pullPolicy: IfNotPresent
	    metricsService:
	      # -- Service type.
	  type: ClusterIP
	      # -- Create service.
	  create: true
	      # -- Service port.
	  # Metrics server will be exposed at this port.
	  port: 8000
	      # -- Service node port.
	  # Only used if `metricsService.type` is `NodePort`.
	  nodePort: 
	      # -- Service annotations.
	  annotations: {}
	    # -- Startup probe.
	  # The block is directly forwarded into the deployment, so you can use whatever startupProbes configuration you want.
	  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
	  # @default -- See [values.yaml](values.yaml)
	  startupProbe:
	      httpGet:
	        path: /health/liveness
	        port: 9443
	        scheme: HTTPS
	      failureThreshold: 20
	      initialDelaySeconds: 2
	      periodSeconds: 6
	    # -- Liveness probe.
	  # The block is directly forwarded into the deployment, so you can use whatever livenessProbe configuration you want.
	  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
	  # @default -- See [values.yaml](values.yaml)
	  livenessProbe:
	      httpGet:
	        path: /health/liveness
	        port: 9443
	        scheme: HTTPS
	      initialDelaySeconds: 15
	      periodSeconds: 30
	      timeoutSeconds: 5
	      failureThreshold: 2
	      successThreshold: 1
	    # -- Readiness Probe.
	  # The block is directly forwarded into the deployment, so you can use whatever readinessProbe configuration you want.
	  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
	  # @default -- See [values.yaml](values.yaml)
	  readinessProbe:
	      httpGet:
	        path: /health/readiness
	        port: 9443
	        scheme: HTTPS
	      initialDelaySeconds: 5
	      periodSeconds: 10
	      timeoutSeconds: 5
	      failureThreshold: 6
	      successThreshold: 1
	    # -- Deployment update strategy.
	  # Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
	  # @default -- See [values.yaml](values.yaml)
	  updateStrategy:
	      type: RollingUpdate
	      rollingUpdate:
	        maxSurge: 1
	        maxUnavailable: 40%!(NOVERB)
	    rbac:
	      # -- Create RBAC resources
	  create: true
	      serviceAccount:
	        # -- Service account name
	  name: 
	        # -- Annotations for the ServiceAccount
	  annotations: {}
	  # example.com/annotation: value
	      clusterRole:
	        # -- Extra resource permissions to add in the cluster role
	  extraResources: []
	  # - apiGroups:
	  #     - ''
	  #   resources:
	  #     - pods
	    # -- Security context for the containers
	  securityContext:
	      runAsNonRoot: true
	      privileged: false
	      allowPrivilegeEscalation: false
	      readOnlyRootFilesystem: true
	      capabilities:
	        drop:
	        - ALL
	      seccompProfile:
	        type: RuntimeDefault
	    # -- Pod anti affinity constraints.
	  # @default -- See [values.yaml](values.yaml)
	  podAntiAffinity:
	      preferredDuringSchedulingIgnoredDuringExecution:
	      - weight: 1
	        podAffinityTerm:
	          labelSelector:
	            matchExpressions:
	            - key: app.kubernetes.io/component
	              operator: In
	              values:
	              - cleanup-controller
	          topologyKey: kubernetes.io/hostname
	  # Reports controller configuration
	  reportsController:
	    resources:
	      # -- Pod resource limits
	  limits:
	        memory: 128Mi
	      # -- Pod resource requests
	  requests:
	        cpu: 100m
	        memory: 64Mi
	    # -- Node labels for pod assignment
	  nodeSelector: {}
	    # -- Additional container environment variables.
	  extraEnvVars: []
	    # -- Overrides features defined at the root level
	  featuresOverride: {}
	    # -- Volume to be mounted in pods for TUF/cosign work.
	  sigstoreVolume:
	      emptyDir: {}
	    # -- Image pull secrets
	  imagePullSecrets: []
	  # - secretName
	    # -- (int) Desired number of pods
	  replicas: ~
	    # -- Additional labels to add to each pod
	  podLabels: {}
	  # example.com/label: foo
	    # -- Additional annotations to add to each pod
	  podAnnotations: {}
	  # example.com/annotation: foo
	    # -- A writable volume to use for the TUF root initialization.
	  tufRootMountPath: /.sigstore
	    # -- Optional priority class
	  priorityClassName: 
	    # -- Change `hostNetwork` to `true` when you want the pod to share its host's network namespace.
	  # Useful for situations like when you end up dealing with a custom CNI over Amazon EKS.
	  # Update the `dnsPolicy` accordingly as well to suit the host network mode.
	  hostNetwork: false
	    # -- `dnsPolicy` determines the manner in which DNS resolution happens in the cluster.
	  # In case of `hostNetwork: true`, usually, the `dnsPolicy` is suitable to be `ClusterFirstWithHostNet`.
	  # For further reference: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy.
	  dnsPolicy: ClusterFirst
	    # -- Extra arguments passed to the container on the command line
	  extraArgs: {}
	    # -- Security context for the pod
	  podSecurityContext: {}
	    # -- List of node taints to tolerate
	  tolerations: []
	    # -- Topology spread constraints.
	  topologySpreadConstraints: []
	    # -- Enable reports controller.
	  enabled: true
	    # -- Node affinity constraints.
	  nodeAffinity: {}
	    # -- Pod affinity constraints.
	  podAffinity: {}
	    tracing:
	      # -- Enable tracing
	  enabled: false
	      # -- (string) Traces receiver address
	  address: ~
	      # -- (string) Traces receiver port
	  port: ~
	      # -- (string) Traces receiver credentials
	  creds: ~
	    metering:
	      # -- Disable metrics export
	  disabled: false
	      # -- Otel configuration, can be `prometheus` or `grpc`
	  config: prometheus
	      # -- Prometheus endpoint port
	  port: 8000
	      # -- (string) Otel collector endpoint
	  collector: ~
	      # -- (string) Otel collector credentials
	  creds: ~
	    networkPolicy:
	      # -- When true, use a NetworkPolicy to allow ingress to the webhook
	  # This is useful on clusters using Calico and/or native k8s network policies in a default-deny setup.
	  enabled: false
	      # -- A list of valid from selectors according to https://kubernetes.io/docs/concepts/services-networking/network-policies.
	  ingressFrom: []
	    serviceMonitor:
	      # -- Create a `ServiceMonitor` to collect Prometheus metrics.
	  enabled: false
	      # -- Additional labels
	  additionalLabels: {}
	      # -- (string) Override namespace
	  namespace: ~
	      # -- Interval to scrape metrics
	  interval: 30s
	      # -- Timeout if metrics can't be retrieved in given time interval
	  scrapeTimeout: 25s
	      # -- Is TLS required for endpoint
	  secure: false
	      # -- TLS Configuration for endpoint
	  tlsConfig: {}
	      # -- RelabelConfigs to apply to samples before scraping
	  relabelings: []
	      # -- MetricRelabelConfigs to apply to samples before ingestion.
	  metricRelabelings: []
	    podDisruptionBudget:
	      # -- Configures the minimum available pods for disruptions.
	  # Cannot be used if `maxUnavailable` is set.
	  minAvailable: 1
	      # -- Configures the maximum unavailable pods for disruptions.
	  # Cannot be used if `minAvailable` is set.
	  maxUnavailable: 
	    antiAffinity:
	      # -- Pod antiAffinities toggle.
	  # Enabled by default but can be disabled if you want to schedule pods to the same node.
	  enabled: true
	    image:
	      # -- Image registry
	  registry: ghcr.io
	      # -- Image repository
	  repository: kyverno/reports-controller
	      # -- (string) Image tag
	  # Defaults to appVersion in Chart.yaml if omitted
	  tag: ~
	      # -- Image pull policy
	  pullPolicy: IfNotPresent
	    metricsService:
	      # -- Service type.
	  type: ClusterIP
	      # -- Create service.
	  create: true
	      # -- Service port.
	  # Metrics server will be exposed at this port.
	  port: 8000
	      # -- (string) Service node port.
	  # Only used if `type` is `NodePort`.
	  nodePort: ~
	      # -- Service annotations.
	  annotations: {}
	    # -- Deployment update strategy.
	  # Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
	  # @default -- See [values.yaml](values.yaml)
	  updateStrategy:
	      type: RollingUpdate
	      rollingUpdate:
	        maxSurge: 1
	        maxUnavailable: 40%!(NOVERB)
	    rbac:
	      # -- Create RBAC resources
	  create: true
	      serviceAccount:
	        # -- Service account name
	  name: 
	        # -- Annotations for the ServiceAccount
	  annotations: {}
	  # example.com/annotation: value
	      clusterRole:
	        # -- Extra resource permissions to add in the cluster role
	  extraResources: []
	  # - apiGroups:
	  #     - ''
	  #   resources:
	  #     - pods
	    # -- Security context for the containers
	  securityContext:
	      runAsNonRoot: true
	      privileged: false
	      allowPrivilegeEscalation: false
	      readOnlyRootFilesystem: true
	      capabilities:
	        drop:
	        - ALL
	      seccompProfile:
	        type: RuntimeDefault
	    # -- Pod anti affinity constraints.
	  # @default -- See [values.yaml](values.yaml)
	  podAntiAffinity:
	      preferredDuringSchedulingIgnoredDuringExecution:
	      - weight: 1
	        podAffinityTerm:
	          labelSelector:
	            matchExpressions:
	            - key: app.kubernetes.io/component
	              operator: In
	              values:
	              - reports-controller
	          topologyKey: kubernetes.io/hostname
	  
	
	
	config
	  - four map entries removed:
	    # -- Name of an existing config map (ignores default/provided resourceFilters)
	    existingConfig: 
	    # -- Exclude group role
	    excludeGroupRole: 
	    # - ''
	    # -- Exclude username
	    excludeUsername: 
	    # -- Metrics config.
	    metricsConfig:
	      namespaces:
	        include: []
	        exclude: []
	    # 'namespaces.include': list of namespaces to capture metrics for. Default: metrics being captured for all namespaces except excludeNamespaces.
	    # 'namespaces.exclude': list of namespaces to NOT capture metrics for. Default: []
	    # metricsRefreshInterval: 24h
	    # rate at which metrics should reset so as to clean up the memory footprint of kyverno metrics, if you might be expecting high memory footprint of Kyverno's metrics. Default: 0, no refresh of metrics
	    
	    # Or provide an existing metrics config-map by uncommenting the below line
	    # existingMetricsConfig: sample-metrics-configmap. Refer to the ./templates/metricsconfigmap.yaml for the structure of metrics configmap.
	    
	  
	  + twelve map entries added:
	    # -- (string) The configmap name (required if `create` is `false`).
	    name: ~
	    # -- Create the configmap.
	    create: true
	    # -- Additional annotations to add to the configmap.
	    annotations: {}
	    # -- Enable registry mutation for container images. Enabled by default.
	    enableDefaultRegistryMutation: true
	    # -- The registry hostname used for the image mutation.
	    defaultRegistry: docker.io
	    # -- Exclude usernames
	    excludeUsernames: []
	    # - '!system:kube-scheduler'
	    # -- Exclude roles
	    excludeRoles: []
	    # -- Exclude roles
	    excludeClusterRoles: []
	    # -- Defines annotations to set on webhook configurations.
	    webhookAnnotations: {}
	    # Example to disable admission enforcer on AKS:
	    # 'admissions.enforcer/disabled': 'true'
	    # -- Exclude Kyverno namespace
	    # Determines if default Kyverno namespace exclusion is enabled for webhooks and resourceFilters
	    excludeKyvernoNamespace: true
	    # -- resourceFilter namespace exclude
	    # Namespaces to exclude from the default resourceFilters
	    resourceFiltersExcludeNamespaces: []
	    # -- Exclude groups
	    excludeGroups:
	    - "system:nodes"
	    
	  
	
	config.resourceFilters
	  - 20 list entries removed:
	    - "[*,kube-system,*]"
	    - "[*,kube-public,*]"
	    - "[*,kube-node-lease,*]"
	    - "[ReportChangeRequest,*,*]"
	    - "[ClusterReportChangeRequest,*,*]"
	    - "[ClusterRole,*,{{ template "kyverno.fullname" . }}:*]"
	    - "[ClusterRoleBinding,*,{{ template "kyverno.fullname" . }}:*]"
	    - "[ServiceAccount,{{ include "kyverno.namespace" . }},{{ template "kyverno.serviceAccountName" . }}]"
	    - "[ConfigMap,{{ include "kyverno.namespace" . }},{{ template "kyverno.configMapName" . }}]"
	    - "[ConfigMap,{{ include "kyverno.namespace" . }},{{ template "kyverno.metricsConfigMapName" . }}]"
	    - "[Deployment,{{ include "kyverno.namespace" . }},{{ template "kyverno.fullname" . }}]"
	    - "[NetworkPolicy,{{ include "kyverno.namespace" . }},{{ template "kyverno.fullname" . }}]"
	    - "[PodDisruptionBudget,{{ include "kyverno.namespace" . }},{{ template "kyverno.fullname" . }}]"
	    - "[Role,{{ include "kyverno.namespace" . }},{{ template "kyverno.fullname" . }}:*]"
	    - "[RoleBinding,{{ include "kyverno.namespace" . }},{{ template "kyverno.fullname" . }}:*]"
	    - "[Secret,{{ include "kyverno.namespace" . }},{{ template "kyverno.serviceName" . }}.{{ template "kyverno.namespace" . }}.svc.*]"
	    - "[Service,{{ include "kyverno.namespace" . }},{{ template "kyverno.serviceName" . }}]"
	    - "[Service,{{ include "kyverno.namespace" . }},{{ template "kyverno.serviceName" . }}-metrics]"
	    - "[ServiceMonitor,{{ if .Values.serviceMonitor.namespace }}{{ .Values.serviceMonitor.namespace }}{{ else }}{{ template "kyverno.namespace" . }}{{ end }},{{ template "kyverno.serviceName" . }}-service-monitor]"
	    - "[Pod,{{ include "kyverno.namespace" . }},{{ template "kyverno.fullname" . }}-test]"
	    
	  
	  + 100 list entries added:
	    - "[*/*,kube-system,*]"
	    - "[*/*,kube-public,*]"
	    - "[*/*,kube-node-lease,*]"
	    - "[Node/*,*,*]"
	    - "[APIService/*,*,*]"
	    - "[Pod/binding,*,*]"
	    - "[ReplicaSet/*,*,*]"
	    - "[AdmissionReport,*,*]"
	    - "[AdmissionReport/*,*,*]"
	    - "[ClusterAdmissionReport,*,*]"
	    - "[ClusterAdmissionReport/*,*,*]"
	    - "[BackgroundScanReport,*,*]"
	    - "[BackgroundScanReport/*,*,*]"
	    - "[ClusterBackgroundScanReport,*,*]"
	    - "[ClusterBackgroundScanReport/*,*,*]"
	    - "[ClusterRole,*,{{ template "kyverno.admission-controller.roleName" . }}]"
	    - "[ClusterRole,*,{{ template "kyverno.admission-controller.roleName" . }}:core]"
	    - "[ClusterRole,*,{{ template "kyverno.admission-controller.roleName" . }}:additional]"
	    - "[ClusterRole,*,{{ template "kyverno.background-controller.roleName" . }}]"
	    - "[ClusterRole,*,{{ template "kyverno.background-controller.roleName" . }}:core]"
	    - "[ClusterRole,*,{{ template "kyverno.background-controller.roleName" . }}:additional]"
	    - "[ClusterRole,*,{{ template "kyverno.cleanup-controller.roleName" . }}]"
	    - "[ClusterRole,*,{{ template "kyverno.cleanup-controller.roleName" . }}:core]"
	    - "[ClusterRole,*,{{ template "kyverno.cleanup-controller.roleName" . }}:additional]"
	    - "[ClusterRole,*,{{ template "kyverno.reports-controller.roleName" . }}]"
	    - "[ClusterRole,*,{{ template "kyverno.reports-controller.roleName" . }}:core]"
	    - "[ClusterRole,*,{{ template "kyverno.reports-controller.roleName" . }}:additional]"
	    - "[ClusterRoleBinding,*,{{ template "kyverno.admission-controller.roleName" . }}]"
	    - "[ClusterRoleBinding,*,{{ template "kyverno.background-controller.roleName" . }}]"
	    - "[ClusterRoleBinding,*,{{ template "kyverno.cleanup-controller.roleName" . }}]"
	    - "[ClusterRoleBinding,*,{{ template "kyverno.reports-controller.roleName" . }}]"
	    - "[ServiceAccount,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.serviceAccountName" . }}]"
	    - "[ServiceAccount/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.serviceAccountName" . }}]"
	    - "[ServiceAccount,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.serviceAccountName" . }}]"
	    - "[ServiceAccount/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.serviceAccountName" . }}]"
	    - "[ServiceAccount,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.serviceAccountName" . }}]"
	    - "[ServiceAccount/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.serviceAccountName" . }}]"
	    - "[ServiceAccount,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.serviceAccountName" . }}]"
	    - "[ServiceAccount/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.serviceAccountName" . }}]"
	    - "[Role,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.roleName" . }}]"
	    - "[Role,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.roleName" . }}]"
	    - "[Role,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.roleName" . }}]"
	    - "[Role,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.roleName" . }}]"
	    - "[RoleBinding,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.roleName" . }}]"
	    - "[RoleBinding,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.roleName" . }}]"
	    - "[RoleBinding,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.roleName" . }}]"
	    - "[RoleBinding,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.roleName" . }}]"
	    - "[ConfigMap,{{ include "kyverno.namespace" . }},{{ template "kyverno.config.configMapName" . }}]"
	    - "[ConfigMap,{{ include "kyverno.namespace" . }},{{ template "kyverno.config.metricsConfigMapName" . }}]"
	    - "[Deployment,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.name" . }}]"
	    - "[Deployment/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.name" . }}]"
	    - "[Deployment,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name" . }}]"
	    - "[Deployment/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name" . }}]"
	    - "[Deployment,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name" . }}]"
	    - "[Deployment/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name" . }}]"
	    - "[Deployment,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name" . }}]"
	    - "[Deployment/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name" . }}]"
	    - "[Pod,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.name" . }}-*]"
	    - "[Pod/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.name" . }}-*]"
	    - "[Pod,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name" . }}-*]"
	    - "[Pod/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name" . }}-*]"
	    - "[Pod,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name" . }}-*]"
	    - "[Pod/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name" . }}-*]"
	    - "[Pod,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name" . }}-*]"
	    - "[Pod/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name" . }}-*]"
	    - "[Job/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.fullname" . }}-hook-pre-delete]"
	    - "[NetworkPolicy,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.name" . }}]"
	    - "[NetworkPolicy/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.name" . }}]"
	    - "[NetworkPolicy,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name" . }}]"
	    - "[NetworkPolicy/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name" . }}]"
	    - "[NetworkPolicy,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name" . }}]"
	    - "[NetworkPolicy/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name" . }}]"
	    - "[NetworkPolicy,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name" . }}]"
	    - "[NetworkPolicy/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name" . }}]"
	    - "[PodDisruptionBudget,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.name" . }}]"
	    - "[PodDisruptionBudget/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.name" . }}]"
	    - "[PodDisruptionBudget,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name" . }}]"
	    - "[PodDisruptionBudget/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name" . }}]"
	    - "[PodDisruptionBudget,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name" . }}]"
	    - "[PodDisruptionBudget/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name" . }}]"
	    - "[PodDisruptionBudget,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name" . }}]"
	    - "[PodDisruptionBudget/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name" . }}]"
	    - "[Service,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.serviceName" . }}]"
	    - "[Service/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.serviceName" . }}]"
	    - "[Service,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.serviceName" . }}-metrics]"
	    - "[Service/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.serviceName" . }}-metrics]"
	    - "[Service,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name" . }}-metrics]"
	    - "[Service/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.background-controller.name" . }}-metrics]"
	    - "[Service,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name" . }}]"
	    - "[Service/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name" . }}]"
	    - "[Service,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name" . }}-metrics]"
	    - "[Service/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name" . }}-metrics]"
	    - "[Service,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name" . }}-metrics]"
	    - "[Service/*,{{ include "kyverno.namespace" . }},{{ template "kyverno.reports-controller.name" . }}-metrics]"
	    - "[ServiceMonitor,{{ if .Values.admissionController.serviceMonitor.namespace }}{{ .Values.admissionController.serviceMonitor.namespace }}{{ else }}{{ template "kyverno.namespace" . }}{{ end }},{{ template "kyverno.admission-controller.name" . }}]"
	    - "[ServiceMonitor,{{ if .Values.admissionController.serviceMonitor.namespace }}{{ .Values.admissionController.serviceMonitor.namespace }}{{ else }}{{ template "kyverno.namespace" . }}{{ end }},{{ template "kyverno.background-controller.name" . }}]"
	    - "[ServiceMonitor,{{ if .Values.admissionController.serviceMonitor.namespace }}{{ .Values.admissionController.serviceMonitor.namespace }}{{ else }}{{ template "kyverno.namespace" . }}{{ end }},{{ template "kyverno.cleanup-controller.name" . }}]"
	    - "[ServiceMonitor,{{ if .Values.admissionController.serviceMonitor.namespace }}{{ .Values.admissionController.serviceMonitor.namespace }}{{ else }}{{ template "kyverno.namespace" . }}{{ end }},{{ template "kyverno.reports-controller.name" . }}]"
	    - "[Secret,{{ include "kyverno.namespace" . }},{{ template "kyverno.admission-controller.serviceName" . }}.{{ template "kyverno.namespace" . }}.svc.*]"
	    - "[Secret,{{ include "kyverno.namespace" . }},{{ template "kyverno.cleanup-controller.name" . }}.{{ template "kyverno.namespace" . }}.svc.*]"
	    
	  
	
	config.webhooks
	  ± type change from <nil> to list
	    - <nil>
	    +
	
	webhooksCleanup
	  - one map entry removed:
	    # -- Create a helm pre-delete hook to cleanup webhooks.
	    enable: false
	  
	  + seven map entries added:
	    # -- Create a helm pre-delete hook to cleanup webhooks.
	    enabled: true
	    # -- Image pull secrets
	    imagePullSecrets: []
	    # -- Node labels for pod assignment
	    nodeSelector: {}
	    # -- List of node taints to tolerate
	    tolerations: []
	    # -- Pod anti affinity constraints.
	    podAntiAffinity: {}
	    # -- Pod affinity constraints.
	    podAffinity: {}
	    # -- Node affinity constraints.
	    nodeAffinity: {}
	  