### PR TITLE
Update kyverno version from 3.0.1 to 3.0.5

### DIFF
--- a/helm/kyverno.yaml
+++ b/helm/kyverno.yaml
@@ -1,0 +1,75 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: HelmRepository
+metadata:
+  name: kyverno
+  namespace: kyverno
+spec:
+  interval: 1h0m0s
+  url: https://kyverno.github.io/kyverno/
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: kyverno
+  namespace: kyverno
+  labels:
+    app: kyverno
+    app.kubernetes.io/component: kyverno
+    app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/version: latest
+spec:
+  releaseName: kyverno
+  interval: 1h0m0s
+  chart:
+    spec:
+      chart: kyverno
+      version: 3.0.5
+      sourceRef:
+        kind: HelmRepository
+        name: kyverno
+  values:
+    admissionController:
+      podAnnotations:
+        ad.datadoghq.com/kyverno.check_names: '["openmetrics"]'
+        ad.datadoghq.com/kyverno.init_configs: '[{}]'
+        ad.datadoghq.com/kyverno.instances: '[{"prometheus_url": "http://kyverno-svc-metrics.kyverno.svc.cluster.local:8000/metrics","namespace": "kyverno","max_returned_metrics":"10000", "metrics": ["kyverno_policy_rule_info_total","kyverno_admission_requests", "kyverno_policy_changes", "kyverno_policy_results_total"]}]'
+      replicas: 3
+      container:
+        resources:
+          # -- Pod resource limits
+          limits:
+            memory: 2048Mi
+          # -- Pod resource requests
+          requests:
+            cpu: 1000m
+            memory: 512Mi
+      tolerations:
+        - key: "admin"
+          operator: "Exists"
+          effect: "NoExecute"
+      nodeAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+                - key: cloud.google.com/gke-nodepool
+                  operator: In
+                  values:
+                    - admin
+            weight: 100
+      serviceMonitor:
+        enabled: true
+        additionalLabels:
+          release: kube-prometheus-stack
+    crds.install: false
+    hostNetwork: ${hostNetwork}
+    config:
+      webhooks:
+        - namespaceSelector:
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - twistlock
+    excludeKyvernoNamespace: true


### PR DESCRIPTION
A new chart update has been found!

Recommended image version: **v1.10.3**

Please **take a deep look onto compatibility matrix** for this app, **ensure the version match the cluster** and **update your values** before merging.


	     _        __  __
	   _| |_   _ / _|/ _|  between old_values.yaml
	 / _' | | | | |_| |_       and new_values.yaml
	| (_| | |_| |  _|  _|
	 \__,_|\__, |_| |_|   returned 13 differences
	        |___/
	
	webhooksCleanup
	  + five map entries added:
	    # -- Node labels for pod assignment
	    nodeSelector: {}
	    # -- List of node taints to tolerate
	    tolerations: []
	    # -- Pod anti affinity constraints.
	    podAntiAffinity: {}
	    # -- Pod affinity constraints.
	    podAffinity: {}
	    # -- Node affinity constraints.
	    nodeAffinity: {}
	
	webhooksCleanup.enabled
	  ± value change
	    - false
	    + true
	
	grafana
	  + one map entry added:
	    # -- Grafana dashboard configmap labels
	    labels:
	      grafana_dashboard: 1
	
	features
	  + two map entries added:
	    policyReports:
	      # -- Enables the feature
	    enabled: true
	    deferredLoading:
	      # -- Enables the feature
	    enabled: true
	
	cleanupJobs.admissionReports
	  + nine map entries added:
	    # -- Job resources
	    resources: {}
	    # -- Image pull secrets
	    imagePullSecrets: []
	    # - name: secretName
	    # -- List of node taints to tolerate
	    tolerations: []
	    # -- Node labels for pod assignment
	    nodeSelector: {}
	    # -- Pod Annotations
	    podAnnotations: {}
	    # -- Pod labels
	    podLabels: {}
	    # -- Pod anti affinity constraints.
	    podAntiAffinity: {}
	    # -- Pod affinity constraints.
	    podAffinity: {}
	    # -- Node affinity constraints.
	    nodeAffinity: {}
	
	cleanupJobs.clusterAdmissionReports
	  + nine map entries added:
	    # -- Job resources
	    resources: {}
	    # -- Image pull secrets
	    imagePullSecrets: []
	    # - name: secretName
	    # -- List of node taints to tolerate
	    tolerations: []
	    # -- Node labels for pod assignment
	    nodeSelector: {}
	    # -- Pod Annotations
	    podAnnotations: {}
	    # -- Pod Labels
	    podLabels: {}
	    # -- Pod anti affinity constraints.
	    podAntiAffinity: {}
	    # -- Pod affinity constraints.
	    podAffinity: {}
	    # -- Node affinity constraints.
	    nodeAffinity: {}
	
	admissionController.serviceMonitor
	  + two map entries added:
	    # -- RelabelConfigs to apply to samples before scraping
	    relabelings: []
	    # -- MetricRelabelConfigs to apply to samples before ingestion.
	    metricRelabelings: []
	
	backgroundController
	  + one map entry added:
	    # -- Additional container environment variables.
	    extraEnvVars: []
	
	backgroundController.serviceMonitor
	  + two map entries added:
	    # -- RelabelConfigs to apply to samples before scraping
	    relabelings: []
	    # -- MetricRelabelConfigs to apply to samples before ingestion.
	    metricRelabelings: []
	
	cleanupController
	  + one map entry added:
	    # -- Additional container environment variables.
	    extraEnvVars: []
	
	cleanupController.serviceMonitor
	  + two map entries added:
	    # -- RelabelConfigs to apply to samples before scraping
	    relabelings: []
	    # -- MetricRelabelConfigs to apply to samples before ingestion.
	    metricRelabelings: []
	
	reportsController
	  + one map entry added:
	    # -- Additional container environment variables.
	    extraEnvVars: []
	
	reportsController.serviceMonitor
	  + two map entries added:
	    # -- RelabelConfigs to apply to samples before scraping
	    relabelings: []
	    # -- MetricRelabelConfigs to apply to samples before ingestion.
	    metricRelabelings: []