### PR TITLE
Update datadog-agent version from 3.6.0 to 3.36.3

### DIFF
--- a/helm/datadog.yaml
+++ b/helm/datadog.yaml
@@ -1,0 +1,114 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: HelmRepository
+metadata:
+  name: datadog
+  namespace: datadog
+spec:
+  interval: 1h0m0s
+  url: https://helm.datadoghq.com
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: datadog-agent
+  namespace: datadog
+spec:
+  releaseName: datadog-agent
+  chart:
+    spec:
+      version: 3.36.3
+      chart: datadog
+      sourceRef:
+        kind: HelmRepository
+        name: datadog
+  interval: 1h0m0s
+  values:
+    hostNetwork: true
+    clusterAgent:
+      enabled: true
+      useHostNetwork: true
+      metricsProvider:
+        enabled: true
+        useDatadogMetrics: true
+      env:
+        - name: NO_PROXY
+          value: ${no_proxy}
+        - name: HTTPS_PROXY
+          value: ${proxy}
+        - name: HTTP_PROXY
+          value: ${proxy}
+    datadog:
+      apiKeyExistingSecret: datadog-secret
+      appKeyExistingSecret: datadog-secret
+      serviceMonitoring:
+        enabled: true
+      systemProbe:
+        enableDefaultKernelHeadersPaths: false
+      apm:
+        enabled: true
+      clusterName: ${cluster_name}
+      ignoreAutoConfig:
+        - elastic
+        - istio
+      dogstatsd:
+        port: 8125
+        useHostPort: true
+        nonLocalTraffic: true
+      helmCheck:
+        enabled: true
+      confd:
+        kube_apiserver_metrics.yaml: "init_config:\ninstances:  \n- prometheus_url: https://kubernetes.default/metrics\n  bearer_token_path: /var/run/secrets/kubernetes.io/serviceaccount/token\n  tls_ca_cert: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt\n  skip_proxy: true\n  metric_patterns:\n    include:\n    - apiserver_request_total          "
+      dd_url: https://app.datadoghq.eu
+      env:
+        - name: DD_APM_IGNORE_RESOURCES
+          value: GET /actuator, GET /v1/ping, (GET|POST) /swagger-ui, GET /v3/api-docs
+        - name: NO_PROXY
+          value: ${no_proxy}
+        - name: HTTPS_PROXY
+          value: ${proxy}
+        - name: HTTP_PROXY
+          value: ${proxy}
+        - name: DD_APM_IGNORE_RESOURCES
+          value: GET /actuator, GET /v1/ping, (GET|POST) /swagger-ui, GET /v3/api-docs
+        - name: DD_EXTERNAL_METRICS_PROVIDER_ENABLED
+          value: "true"
+        - name: DD_EXTERNAL_METRICS_PROVIDER_USE_DATADOGMETRIC_CRD
+          value: "true"
+      kubeStateMetricsEnabled: false
+      logs:
+        containerCollectAll: true
+        enabled: true
+      nodeLabelsAsTags:
+        '*': '%%label%%'
+      orchestratorExplorer:
+        enabled: true
+      processAgent:
+        enabled: true
+      site: datadoghq.eu
+    agents:
+      enabled: true
+      useHostNetwork: true
+      tolerations:
+        - effect: NoExecute
+          operator: Exists
+        - effect: NoSchedule
+          operator: Exists
+    kube-state-metrics:
+      containerSecurityContext:
+        runAsNonRoot: true
+      resources:
+        limits:
+          memory: 300Mi
+        requests:
+          cpu: 100m
+          memory: 256Mi
+      securityContext:
+        enabled: true
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsUser: 65534
+      tolerations:
+        - effect: NoExecute
+          operator: Exists
+        - effect: NoSchedule
+          operator: Exists

--- a/helm/kubecost.yaml
+++ b/helm/kubecost.yaml
@@ -1,0 +1,58 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: HelmRepository
+metadata:
+  name: kubecost
+  namespace: kubecost
+spec:
+  interval: 1h0m0s
+  url: https://kubecost.github.io/cost-analyzer/
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: kubecost
+  namespace: kubecost
+spec:
+  releaseName: kubecost
+  interval: 1h0m0s
+  chart:
+    spec:
+      version: 1.106.1
+      chart: cost-analyzer
+      sourceRef:
+        kind: HelmRepository
+        name: kubecost
+  values:
+    global:
+      podAnnotations:
+        ad.datadoghq.com/cost-model.check_names: '["openmetrics"]'
+        ad.datadoghq.com/cost-model.init_configs: '[{}]'
+        ad.datadoghq.com/cost-model.instances: '[{"prometheus_url": "http://kubecost-cost-analyzer.kubecost.svc.cluster.local:9003/metrics","namespace" : "inix", "metrics": ["node_total_hourly_cost", "node_cpu_hourly_cost", "node_ram_hourly_cost", "pv_hourly_cost"]}]'
+      prometheus:
+        enabled: false
+        fqdn: http://kube-prometheus-stack-prometheus.prometheus.svc.cluster.local:9090
+      grafana:
+        enabled: false
+        domainName: http://inix-grafana.pp.dktapp.cloud
+        proxy: false
+    kubecostFrontend:
+      api:
+        fqdn: localhost:9001
+      model:
+        fqdn: localhost:9003
+    ingress:
+      enabled: true
+      annotations:
+        kubernetes.io/ingress.class: nginx
+      hosts:
+        - ${hosts}
+      networkPolicy:
+        enabled: true
+    serviceMonitor:
+      enabled: true
+      additionalLabels:
+        release: "kube-prometheus-stack"
+    prometheusRule:
+      enabled: true
+      additionalLabels:
+        release: "kube-prometheus-stack"

--- a/helm/kyverno.yaml
+++ b/helm/kyverno.yaml
@@ -1,0 +1,75 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: HelmRepository
+metadata:
+  name: kyverno
+  namespace: kyverno
+spec:
+  interval: 1h0m0s
+  url: https://kyverno.github.io/kyverno/
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: kyverno
+  namespace: kyverno
+  labels:
+    app: kyverno
+    app.kubernetes.io/component: kyverno
+    app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/version: latest
+spec:
+  releaseName: kyverno
+  interval: 1h0m0s
+  chart:
+    spec:
+      chart: kyverno
+      version: 3.0.5
+      sourceRef:
+        kind: HelmRepository
+        name: kyverno
+  values:
+    admissionController:
+      podAnnotations:
+        ad.datadoghq.com/kyverno.check_names: '["openmetrics"]'
+        ad.datadoghq.com/kyverno.init_configs: '[{}]'
+        ad.datadoghq.com/kyverno.instances: '[{"prometheus_url": "http://kyverno-svc-metrics.kyverno.svc.cluster.local:8000/metrics","namespace": "kyverno","max_returned_metrics":"10000", "metrics": ["kyverno_policy_rule_info_total","kyverno_admission_requests", "kyverno_policy_changes", "kyverno_policy_results_total"]}]'
+      replicas: 3
+      container:
+        resources:
+          # -- Pod resource limits
+          limits:
+            memory: 2048Mi
+          # -- Pod resource requests
+          requests:
+            cpu: 1000m
+            memory: 512Mi
+      tolerations:
+        - key: "admin"
+          operator: "Exists"
+          effect: "NoExecute"
+      nodeAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+                - key: cloud.google.com/gke-nodepool
+                  operator: In
+                  values:
+                    - admin
+            weight: 100
+      serviceMonitor:
+        enabled: true
+        additionalLabels:
+          release: kube-prometheus-stack
+    crds.install: false
+    hostNetwork: ${hostNetwork}
+    config:
+      webhooks:
+        - namespaceSelector:
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - twistlock
+    excludeKyvernoNamespace: true


### PR DESCRIPTION
A new chart update has been found!

Recommended image version: **7**

Please **take a deep look onto compatibility matrix** for this app, **ensure the version match the cluster** and **update your values** before merging.


	     _        __  __
	   _| |_   _ / _|/ _|  between old_values.yaml
	 / _' | | | | |_| |_       and new_values.yaml
	| (_| | |_| |  _|  _|
	 \__,_|\__, |_| |_|   returned 32 differences
	        |___/
	
	(root level)
	+ two map entries added:
	  # fips is used to enable the fips sidecar container for GOVCLOUD environments.
	  fips:
	    # fips.resources -- Resource requests and limits for the FIPS sidecar container.
	  resources: {}
	  # limits:
	  #   cpu: 100m
	  #   memory: 256Mi
	  # requests:
	  #   cpu: 20m
	  #   memory: 64Mi
	    enabled: false
	    # TODO: Option to override config of the FIPS side car: /etc/datadog-fips-proxy/datadog-fips-proxy.cfg
	  # customConfig: false
	  
	  # fips.port specifies which port is used by the containers to communicate to the FIPS sidecar.
	  port: 9803
	    # fips.portRange specifies the number of ports used, defaults to 13  https://github.com/DataDog/datadog-agent/blob/7.44.x/pkg/config/config.go#L1564-L1577
	  portRange: 15
	    use_https: false
	    local_address: 127.0.0.1
	    # fips.customFipsConfig -- Configure a custom configMap to provide the FIPS configuration. Specify custom contents for the FIPS proxy sidecar container config (/etc/datadog-fips-proxy/datadog-fips-proxy.cfg). If empty, the default FIPS proxy sidecar container config is used.
	  
	  ## Note: Use `|` to declare multi-line configuration.
	  ## ref: https://docs.datadoghq.com/agent/guide/agent-fips-proxy
	  customFipsConfig: {}
	  #  foobar
	  #     foo bar baz
	    ## Define the Datadog image to work with
	  image:
	      ## fips.image.name -- Define the FIPS sidecar container image name.
	  name: fips-proxy
	      # fips.image.tag -- Define the FIPS sidecar container version to use.
	  tag: 0.5.5
	      # fips.image.pullPolicy -- Datadog the FIPS sidecar image pull policy
	  pullPolicy: IfNotPresent
	      # fips.image.digest -- Define the FIPS sidecar image digest to use, takes precedence over `fips.image.tag` if specified.
	  digest: 
	      # fips.image.repository -- Override default registry + image.name for the FIPS sidecar container.
	  repository: 
	  remoteConfiguration:
	    # remoteConfiguration.enabled -- Set to true to enable remote configuration on the Cluster Agent (if set) and the node agent.
	  # Can be overriden if `datadog.remoteConfiguration.enabled` or `clusterAgent.admissionController.remoteInstrumentation.enabled` is set to `false`.
	  # Preferred way to enable Remote Configuration.
	  enabled: true
	  
	
	
	datadog
	  + five map entries added:
	    # agents.secretAnnotations -- Annotations to add to the Secrets
	    secretAnnotations: {}
	    #   key: "value"
	    # Configure Kubernetes events collection
	    kubernetesEvents:
	      # datadog.kubernetesEvents.unbundleEvents -- Allow unbundling kubernetes events, 1:1 mapping between Kubernetes and Datadog events. (Requires Cluster Agent 7.42.0+).
	    unbundleEvents: false
	      # datadog.kubernetesEvents.collectedEventTypes -- Event types to be collected. This requires datadog.kubernetesEvents.unbundleEvents to be set to true.
	    collectedEventTypes:
	      - kind: Pod
	        reasons:
	        - Failed
	        - BackOff
	        - Unhealthy
	        - FailedScheduling
	        - FailedMount
	        - FailedAttachVolume
	      - kind: Node
	        reasons:
	        - TerminatingEvictedPod
	        - NodeNotReady
	        - Rebooted
	        - HostPortConflict
	      - kind: CronJob
	        reasons:
	        - SawCompletedJob
	    clusterTagger:
	      # datadog.clusterTagger.collectKubernetesTags -- Enables Kubernetes resources tags collection.
	    collectKubernetesTags: false
	    remoteConfiguration:
	      # datadog.remoteConfiguration.enabled -- Set to true to enable remote configuration.
	    # Consider using remoteConfiguration.enabled instead
	    enabled: true
	    # datadog.envDict -- Set environment variables for all Agents defined in a dict
	    envDict: {}
	    #   <ENV_VAR_NAME>: <ENV_VAR_VALUE>
	    
	  
	
	datadog.kubeStateMetricsCore
	  + three map entries added:
	    # datadog.kubeStateMetricsCore.collectCrdMetrics -- Enable watching CRD objects and collecting their corresponding metrics kubernetes_state.crd.*
	    
	    ## Configuring this field will change the default kubernetes_state_core check configuration to run the kubernetes_state_core check.
	    collectCrdMetrics: false
	    # datadog.kubeStateMetricsCore.collectApiServicesMetrics -- Enable watching apiservices objects and collecting their corresponding metrics kubernetes_state.apiservice.* (Requires Cluster Agent 7.45.0+)
	    
	    ## Configuring this field will change the default kubernetes_state_core check configuration and the RBACs granted to Datadog Cluster Agent to run the kubernetes_state_core check.
	    collectApiServicesMetrics: false
	    # datadog.kubeStateMetricsCore.annotationsAsTags -- Extra annotations to collect from resources and to turn into datadog tag.
	    
	    ## It has the following structure:
	    ## annotationsAsTags:
	    ##   <resource1>:        # can be pod, deployment, node, etc.
	    ##     <annotation1>: <tag1>  # where <annotation1> is the kubernetes annotation and <tag1> is the datadog tag
	    ##     <annotation2>: <tag2>
	    ##   <resource2>:
	    ##     <annotation3>: <tag3>
	    ##
	    ## Warning: the annotation must match the transformation done by kube-state-metrics,
	    ## for example tags.datadoghq.com/version becomes tags_datadoghq_com_version.
	    annotationsAsTags: {}
	    #  pod:
	    #    app: app
	    #  node:
	    #    zone: zone
	    #    team: team
	    
	  
	
	datadog.processAgent.processDiscovery
	  ± value change
	    - false
	    + true
	
	datadog.securityAgent.compliance
	  + one map entry added:
	    # datadog.securityAgent.compliance.xccdf.enabled -- Set to true to enable XCCDF (this feature is supported from Agent 7.45, and requires 160 MB extra memory for the `security-agent` container)
	    xccdf:
	      enabled: false
	    
	  
	
	datadog.securityAgent.runtime
	  + one map entry added:
	    securityProfile:
	      # datadog.securityAgent.runtime.securityProfile.enabled -- Set to true to enable CWS runtime anomaly detection
	    enabled: false
	    
	  
	
	datadog.securityAgent.runtime.network.enabled
	  ± value change
	    - false
	    + true
	
	datadog.securityAgent.runtime.activityDump.enabled
	  ± value change
	    - false
	    + true
	
	clusterAgent
	  + two map entries added:
	    # clusterAgent.envDict -- Set environment variables specific to Cluster Agent defined in a dict
	    envDict: {}
	    #   <ENV_VAR_NAME>: <ENV_VAR_VALUE>
	    # clusterAgent.topologySpreadConstraints -- Allow the Cluster Agent Deployment to schedule using pod topology spreading
	    
	    ## By default, no constraints are set, allowing cluster defaults to be used for scheduling
	    ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
	    topologySpreadConstraints: []
	    
	  
	
	clusterAgent.image.tag
	  ± value change
	    - 7.41.0
	    + 7.47.0
	
	clusterAgent.containers
	  + one map entry added:
	    initContainers:
	      # clusterAgent.containers.initContainer.securityContext -- Specify securityContext on the initContainers.
	    securityContext: {}
	    
	  
	
	clusterAgent.containers.clusterAgent.securityContext
	  + two map entries added:
	    allowPrivilegeEscalation: false
	    readOnlyRootFilesystem: true
	
	clusterAgent.rbac
	  + two map entries added:
	    # clusterAgent.rbac.flareAdditionalPermissions -- If true, add Secrets and Configmaps get/list permissions to retrieve user Datadog Helm values from Cluster Agent namespace
	    flareAdditionalPermissions: true
	    # clusterAgent.rbac.automountServiceAccountToken -- If true, automatically mount the ServiceAccount's API credentials if clusterAgent.rbac.create is true
	    automountServiceAccountToken: true
	    
	  
	
	clusterAgent.admissionController
	  + three map entries added:
	    # clusterAgent.admissionController.webhookName -- Name of the mutatingwebhookconfigurations created by the cluster-agent
	    webhookName: datadog-webhook
	    remoteInstrumentation:
	      # clusterAgent.admissionController.remoteInstrumentation.enabled -- Enable polling and applying library injection using Remote Config.
	    ## This feature is in beta, and enables Remote Config in the Cluster Agent. It also requires Cluster Agent version 7.43+.
	    ## Enabling this feature grants the Cluster Agent the permissions to patch Deployment objects in the cluster.
	    enabled: true
	    # clusterAgent.admissionController.port -- Set port of cluster-agent admission controller service
	    port: 8000
	    
	  
	
	agents.image.tag
	  ± value change
	    - 7.41.0
	    + 7.47.0
	
	agents.rbac
	  + one map entry added:
	    # agents.rbac.automountServiceAccountToken -- If true, automatically mount the ServiceAccount's API credentials if agents.rbac.create is true
	    automountServiceAccountToken: true
	    
	  
	
	agents.podSecurity.capabilities
	  + one list entry added:
	    - DAC_READ_SEARCH
	
	agents.containers.agent
	  + one map entry added:
	    # agents.containers.agent.envDict -- Set environment variables specific to agent container defined in a dict
	    envDict: {}
	    #   <ENV_VAR_NAME>: <ENV_VAR_VALUE>
	    
	  
	
	agents.containers.processAgent
	  + one map entry added:
	    # agents.containers.processAgent.envDict -- Set environment variables specific to process-agent defined in a dict
	    envDict: {}
	    #   <ENV_VAR_NAME>: <ENV_VAR_VALUE>
	    
	  
	
	agents.containers.traceAgent
	  + one map entry added:
	    # agents.containers.traceAgent.envDict -- Set environment variables specific to trace-agent defined in a dict
	    envDict: {}
	    #   <ENV_VAR_NAME>: <ENV_VAR_VALUE>
	    
	  
	
	agents.containers.traceAgent.env
	  ± type change from <nil> to list
	    - <nil>
	    +
	
	agents.containers.systemProbe
	  + one map entry added:
	    # agents.containers.systemProbe.envDict -- Set environment variables specific to system-probe defined in a dict
	    envDict: {}
	    #   <ENV_VAR_NAME>: <ENV_VAR_VALUE>
	    
	  
	
	agents.containers.systemProbe.securityContext.capabilities.add
	  + one list entry added:
	    - DAC_READ_SEARCH
	
	agents.containers.securityAgent
	  + one map entry added:
	    # agents.containers.securityAgent.envDict -- Set environment variables specific to security-agent defined in a dict
	    envDict: {}
	    #   <ENV_VAR_NAME>: <ENV_VAR_VALUE>
	    
	  
	
	agents.containers.securityAgent.env
	  ± type change from <nil> to list
	    - <nil>
	    +
	
	agents.containers.initContainers
	  + one map entry added:
	    #  requests:
	    #    cpu: 100m
	    #    memory: 200Mi
	    #  limits:
	    #    cpu: 100m
	    #    memory: 200Mi
	    # agents.containers.initContainers.securityContext -- Allows you to overwrite the default container SecurityContext for the init containers.
	    securityContext: {}
	    
	  
	
	clusterChecksRunner
	  + two map entries added:
	    # clusterChecksRunner.topologySpreadConstraints -- Allow the ClusterChecks Deployment to schedule using pod topology spreading
	    
	    ## By default, no constraints are set, allowing cluster defaults to be used for scheduling
	    ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
	    topologySpreadConstraints: []
	    # clusterChecksRunner.envDict -- Set environment variables specific to Cluster Checks Runner defined in a dict
	    envDict: {}
	    #   <ENV_VAR_NAME>: <ENV_VAR_VALUE>
	    
	  
	
	clusterChecksRunner.image.tag
	  ± value change
	    - 7.41.0
	    + 7.47.0
	
	clusterChecksRunner.rbac
	  + one map entry added:
	    # clusterChecksRunner.rbac.automountServiceAccountToken -- If true, automatically mount the ServiceAccount's API credentials if clusterChecksRunner.rbac.create is true
	    automountServiceAccountToken: true
	    
	  
	
	kube-state-metrics
	  + one map entry added:
	    # kube-state-metrics.image.repository -- Default kube-state-metrics image repository.
	    image:
	      repository: registry.k8s.io/kube-state-metrics/kube-state-metrics
	    
	  
	
	providers
	  + one map entry added:
	    aks:
	      # providers.aks.enabled -- Activate all specifities related to AKS configuration. Required as currently we cannot auto-detect AKS.
	    enabled: false
	    
	  
	
	providers.gke
	  + one map entry added:
	    # providers.gke.cos -- Enables Datadog Agent deployment on GKE with Container-Optimized OS (COS)
	    cos: false
	    
	  