### PR TITLE
Update kubecost version from 1.98.0 to 1.106.1

### DIFF
--- a/helm/kubecost.yaml
+++ b/helm/kubecost.yaml
@@ -17,7 +17,7 @@ spec:
   interval: 1h0m0s
   chart:
     spec:
-      version: 1.98.0
+      version: 1.106.1
       chart: cost-analyzer
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
A new chart update has been found for chart !

---

Updating release **kubecost** from **1.98.0** to **1.106.1**
Recommended image version: **1.106.1**

---

Please :

- [ ] **Take a deep look onto compatibility matrix** for this app
- [ ] **Ensure the version match the cluster**
- [ ] **Update your values** before merging.

Once everything seems goods, feel free to merge !

---

### Values diff
	     _        __  __
	   _| |_   _ / _|/ _|  between old_values.yaml
	 / _' | | | | |_| |_       and new_values.yaml
	| (_| | |_| |  _|  _|
	 \__,_|\__, |_| |_|   returned 33 differences
	        |___/
	
	(root level)
	+ three map entries added:
	  kubecostAdmissionController:
	    enabled: false
	  # Enables or disables the Cost Event Audit pipeline, which tracks recent changes at cluster level
	  # and provides an estimated cost impact via the Kubecost Predict API.
	  #
	  # It is disabled by default to avoid problems in high-scale environments.
	  costEventsAudit:
	    enabled: false
	  #readonly: false # disable updates to kubecost from the frontend UI and via POST request
	  
	  # These configs can also be set from the Settings page in the Kubecost product UI
	  # Values in this block override config changes in the Settings UI on pod restart
	  #
	  #kubecostProductConfigs:
	  # An optional list of cluster definitions that can be added for frontend access. The local
	  # cluster is *always* included by default, so this list is for non-local clusters.
	  # Ref: https://github.com/kubecost/docs/blob/main/multi-cluster.md
	  #  clusters:
	  #   - name: "Cluster A"
	  #     address: http://cluster-a.kubecost.com:9090
	  #     # Optional authentication credentials - only basic auth is currently supported.
	  #     auth:
	  #       type: basic
	  #       # Secret name should be a secret formatted based on: https://github.com/kubecost/docs/blob/main/ingress-examples.md
	  #       secretName: cluster-a-auth
	  #       # Or pass auth directly as base64 encoded user:pass
	  #       data: YWRtaW46YWRtaW4=
	  #       # Or user and pass directly
	  #       user: admin
	  #       pass: admin
	  #   - name: "Cluster B"
	  #     address: http://cluster-b.kubecost.com:9090
	  #  defaultModelPricing: # default monthly resource prices, used predominately for on-prem clusters. Use quotes if setting "0.00" for any item.
	  #    CPU: 28.0
	  #    spotCPU: 4.86
	  #    RAM: 3.09
	  #    spotRAM: 0.65
	  #    GPU: 693.50
	  #    spotGPU: 225.0
	  #    storage: 0.04
	  #    zoneNetworkEgress: 0.01
	  #    regionNetworkEgress: 0.01
	  #    internetNetworkEgress: 0.12
	  #    enabled: true
	  #  # The cluster profile represents a predefined set of parameters to use when calculating savings.
	  #  # Possible values are: [ development, production, high-availability ]
	  #  clusterProfile: production
	  #  customPricesEnabled: false # This makes the default view custom prices-- generally used for on-premises clusters
	  #  spotLabel: lifecycle
	  #  spotLabelValue: Ec2Spot
	  #  gpuLabel: gpu
	  #  gpuLabelValue: true
	  #  awsServiceKeyName: ACCESSKEYID
	  #  awsServiceKeyPassword:  fakepassword # Only use if your values.yaml are stored encrypted. Otherwise provide an existing secret via serviceKeySecretName
	  #  awsSpotDataRegion: us-east-1
	  #  awsSpotDataBucket: spot-data-feed-s3-bucket
	  #  awsSpotDataPrefix: dev
	  #  athenaProjectID: "530337586277" # The AWS AccountID where the Athena CUR is. Generally your masterpayer account
	  #  athenaBucketName: "s3://aws-athena-query-results-530337586277-us-east-1"
	  #  athenaRegion: us-east-1
	  #  athenaDatabase: athenacurcfn_athena_test1
	  #  athenaTable: "athena_test1"
	  #  athenaWorkgroup: "primary" # The default workgroup in AWS is 'primary'
	  #  masterPayerARN: ""
	  #  projectID: "123456789"  # Also known as AccountID on AWS -- the current account/project that this instance of Kubecost is deployed on.
	  #  gcpSecretName: gcp-secret # Name of a secret representing the gcp service key
	  #  bigQueryBillingDataDataset: billing_data.gcp_billing_export_v1_01AC9F_74CF1D_5565A2
	  #  labelMappingConfigs:  # names of k8s labels or annotations used to designate different allocation concepts
	  #    enabled: true
	  #    owner_label: "owner"
	  #    team_label: "team"
	  #    department_label: "dept"
	  #    product_label: "product"
	  #    environment_label: "env"
	  #    namespace_external_label: "kubernetes_namespace" # external labels/tags are used to map external cloud costs to kubernetes concepts
	  #    cluster_external_label: "kubernetes_cluster"
	  #    controller_external_label: "kubernetes_controller"
	  #    product_external_label: "kubernetes_label_app"
	  #    service_external_label: "kubernetes_service"
	  #    deployment_external_label: "kubernetes_deployment"
	  #    owner_external_label: "kubernetes_label_owner"
	  #    team_external_label: "kubernetes_label_team"
	  #    environment_external_label: "kubernetes_label_env"
	  #    department_external_label: "kubernetes_label_department"
	  #    statefulset_external_label: "kubernetes_statefulset"
	  #    daemonset_external_label: "kubernetes_daemonset"
	  #    pod_external_label: "kubernetes_pod"
	  #  grafanaURL: ""
	  #  clusterName: "" # clusterName is the default context name in settings.
	  #  clusterAccountID: "" # Manually set Account property for assets
	  #  currencyCode: "USD" # official support for USD, AUD, BRL, CAD, CHF, CNY, DKK, EUR, GBP, INR, JPY, NOK, PLN, SEK
	  #  azureBillingRegion: US # Represents 2-letter region code, e.g. West Europe = NL, Canada = CA. ref: https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes
	  #  azureSubscriptionID: 0bd50fdf-c923-4e1e-850c-196dd3dcc5d3
	  #  azureClientID: f2ef6f7d-71fb-47c8-b766-8d63a19db017
	  #  azureTenantID: 72faf3ff-7a3f-4597-b0d9-7b0b201bb23a
	  #  azureClientPassword: fake key # Only use if your values.yaml are stored encrypted. Otherwise provide an existing secret via serviceKeySecretName
	  #  azureOfferDurableID: "MS-AZR-0003p"
	  #  discount: "" # percentage discount applied to compute
	  #  negotiatedDiscount: "" # custom negotiated cloud provider discount
	  #  defaultIdle: false
	  #  serviceKeySecretName: "" # Use an existing AWS or Azure secret with format as in aws-service-key-secret.yaml or azure-service-key-secret.yaml. Leave blank if using createServiceKeySecret
	  #  createServiceKeySecret: true # Creates a secret representing your cloud service key based on data in values.yaml. If you are storing unencrypted values, add a secret manually
	  #  sharedNamespaces: "" # namespaces with shared workloads, example value: "kube-system\,ingress-nginx\,kubecost\,monitoring"
	  #  sharedOverhead: "" # value representing a fixed external cost per month to be distributed among aggregations.
	  #  shareTenancyCosts: true # enable or disable sharing costs such as cluster management fees (defaults to "true" on Settings page)
	  #  metricsConfigs: # configuration for metrics emitted by Kubecost
	  #    disabledMetrics: [] # list of metrics that Kubecost will not emit. Note that disabling metrics can lead to unexpected behavior in the cost-model.
	  #  productKey: # apply business or enterprise product license
	  #    key: ""
	  #    enabled: false
	  #    secretname: productkeysecret # create a secret out of a file named productkey.json of format { "key": "kc-b1325234" }. If the secretname is specified, a configmap with the key will not be created
	  #    mountPath: "/some/custom/path/productkey.json" # (use instead of secretname) declare the path at which the product key file is mounted (eg. by a secrets provisioner). The file must be of format { "key": "kc-b1325234" }
	  #  cloudIntegrationSecret: "cloud-integration"
	  #  ingestPodUID: false # Enables using UIDs to uniquely ID pods. This requires either Kubecost's replicated KSM metrics, or KSM v2.1.0+. This may impact performance, and changes the default cost-model allocation behavior.
	  #  regionOverrides: "region1,region2,region3" # list of regions which will override default costmodel provider regions
	  
	  #kubecostAdmissionController:
	  #  enabled: true
	  #  secretName: webhook-server-tls
	  #  caBundle: ${CA_BUNDLE}
	  
	  # -- Array of extra K8s manifests to deploy
	  ## Note: Supports use of custom Helm templates
	  extraObjects: []
	  # Cloud Billing Integration:
	  #   - apiVersion: v1
	  #     kind: Secret
	  #     metadata:
	  #       name: cloud-integration
	  #       namespace: kubecost
	  #     type: Opaque
	  #     data:
	  #       cloud-integration.json: BASE64_SECRET
	  #  Istio:
	  #   - apiVersion: networking.istio.io/v1alpha3
	  #     kind: VirtualService
	  #     metadata:
	  #       name: my-virtualservice
	  #     spec:
	  #       hosts:
	  #       - kubecost.myorg.com
	  #       gateways:
	  #       - my-gateway
	  #       http:
	  #       - route:
	  #         - destination:
	  #             host: kubecost.kubecost.svc.cluster.local
	  #             port:
	  #               number: 80
	  
	
	
	global
	  + six map entries added:
	    # Enable only when you are using GCP Marketplace ENT listing. Learn more at https://console.cloud.google.com/marketplace/product/kubecost-public/kubecost-ent
	    gcpstore:
	      enabled: false
	    # Google Cloud Managed Service for Prometheus
	    gmp:
	      # Remember to set up these parameters when install the Kubecost Helm chart with `global.gmp.enabled=true` if you want to use GMP self-deployed collection (Recommended) to ultilize Kubecost scrape configs.
	    # If enabling GMP, it is highly recommended to utilize Google's distribution of Prometheus.
	    # Learn more at https://cloud.google.com/stackdriver/docs/managed-prometheus/setup-unmanaged
	    # --set prometheus.server.image.repository="gke.gcr.io/prometheus-engine/prometheus" \
	    # --set prometheus.server.image.tag="v2.35.0-gmp.2-gke.0"
	    enabled: false # If true, kubecost will be configured to use GMP Prometheus image and query from Google Cloud Managed Service for Prometheus.
	      prometheusServerEndpoint: "http://localhost:8085/" # The prometheus service endpoint used by kubecost. The calls are forwarded through the GMP Prom proxy side car to the GMP database.
	      gmpProxy:
	        name: gmp-proxy
	        enabled: false
	        image: "gke.gcr.io/prometheus-engine/frontend:v0.4.1-gke.0" # GMP Prometheus proxy image that serve as an endpoint to query metrics from GMP
	        imagePullPolicy: Always
	        port: 8085
	        projectId: YOUR_PROJECT_ID # example GCP project ID
	    # Mimir Proxy to help Kubecost to query metrics from multi-tenant Grafana Mimir.
	    # Set `global.mimirProxy.enabled=true` and `global.prometheus.enabled=false` to enable Mimir Proxy.
	    # You also need to set `global.prometheus.fqdn=http://kubecost-cost-analyzer-mimir-proxy.kubecost.svc:8085/prometheus`
	    # or `global.prometheus.fqdn=http://{{ template "cost-analyzer.fullname" . }}-mimir-proxy.{{ .Release.Namespace }}.svc:8085/prometheus'
	    # Learn more at https://grafana.com/docs/mimir/latest/operators-guide/secure/authentication-and-authorization/#without-an-authenticating-reverse-proxy
	    mimirProxy:
	      name: mimir-proxy
	      enabled: false
	      image: nginxinc/nginx-unprivileged
	      port: 8085
	      mimirEndpoint: $mimir_endpoint #Your Mimir query endpoint. If your Mimir query endpoint is http://example.com/prometheus, replace $mimir_endpoint with http://example.com/
	      orgIdentifier: $your_tenant_ID #Your Grafana Mimir tenant ID
	    # Set saved Advanced report(s) accessible from /reports
	    # Ref: http://docs.kubecost.com/saved-reports
	    advancedReports:
	      enabled: false # If true, overwrites report parameters set through UI
	      reports:
	      - title: "Example Advanced Report 0"
	        window: 7d
	        aggregateBy: namespace
	        filters:
	        - property: cluster
	          value: cluster-one
	        cloudBreakdown: service
	        cloudJoin: "label:kubernetes_namespace"
	    # Set saved Cloud Cost report(s) accessible from /reports
	    # Ref: http://docs.kubecost.com/saved-reports
	    cloudCostReports:
	      enabled: false # If true, overwrites report parameters set through UI
	      reports:
	      - title: "Cloud Cost Report 0"
	        window: today
	        aggregateBy: service
	        accumulate: false # daily resolution
	    # filters:
	    #   - property: "service"
	    #     value: "service1" # corresponds to a value to filter cloud cost aggregate by service data on.
	    containerSecuritycontext: {}
	    # readOnlyRootFilesystem: true
	    
	  
	
	global.savedReports.reports
	  - three list entries removed:
	    - title: "Example Saved Report 0"
	      window: today
	      aggregateBy: namespace
	      idle: separate
	      accumulate: false # daily resolution
	      filters:
	      - property: cluster
	        value: "cluster-one,cluster*" # supports wildcard filtering and multiple comma separated values
	      - property: namespace
	        value: kubecost
	    - title: "Example Saved Report 1"
	      window: month
	      aggregateBy: controllerKind
	      idle: share
	      accumulate: false
	      filters:
	      - property: label
	        value: "app:cost*,environment:kube*"
	      - property: namespace
	        value: kubecost
	    - title: "Example Saved Report 2"
	      window: "2020-11-11T00:00:00Z,2020-12-09T23:59:59Z"
	      aggregateBy: service
	      idle: hide
	      accumulate: true # entire window resolution
	      filters: []
	    
	  
	  + three list entries added:
	    - title: "Example Saved Report 0"
	      window: today
	      aggregateBy: namespace
	      chartDisplay: category
	      idle: separate
	      rate: cumulative
	      accumulate: false # daily resolution
	      filters:
	      - property: cluster
	        value: "cluster-one,cluster*" # supports wildcard filtering and multiple comma separated values
	      - property: namespace
	        value: kubecost
	    - title: "Example Saved Report 1"
	      window: month
	      aggregateBy: controllerKind
	      chartDisplay: category
	      idle: share
	      rate: monthly
	      accumulate: false
	      filters:
	      - property: label
	        value: "app:cost*,environment:kube*"
	      - property: namespace
	        value: kubecost
	    - title: "Example Saved Report 2"
	      window: "2020-11-11T00:00:00Z,2020-12-09T23:59:59Z"
	      aggregateBy: service
	      chartDisplay: category
	      idle: hide
	      rate: daily
	      accumulate: true # entire window resolution
	      filters: []
	    
	  
	
	saml.rbac.groups.readonly
	  - one map entry removed:     + one map entry added:
	    assertionvalues:             assertionValues:
	    - readonly                   - readonly
	
	oidc
	  + one map entry added:
	    #  hostedDomain: "example.com" # optional, blocks access to the auth domain specified in the hd claim of the provider ID token
	    rbac:
	      enabled: false
	      groups:
	      - name: admin
	        enabled: false # if admin is disabled, all authenticated users will be able to make configuration changes to the kubecost frontend
	        claimName: roles # Kubecost matches this string against the JWT's payload key containing RBAC info (this value is unique across identity providers)
	        claimValues:
	        - admin
	        - superusers
	      - name: readonly
	        enabled: false # if readonly is disabled, all authenticated users will default to readonly
	        claimName: roles
	        claimValues:
	        - readonly
	      - name: editor
	        enabled: false # if editor is enabled, editors will be allowed to edit reports/alerts scoped to them, and act as readers otherwise. Users will never default to editor.
	        claimName: roles
	        claimValues:
	        - editor
	    
	  
	
	kubecostFrontend
	  + one map entry added:
	    livenessProbe:
	      enabled: true
	      initialDelaySeconds: 30
	      periodSeconds: 10
	      failureThreshold: 200
	
	kubecostMetrics.exporter.serviceMonitor
	  - one map entry removed:     + two map entries added:
	    networkCosts:                metricRelabelings: []
	      enabled: false             relabelings: []
	      scrapeTimeout: 10s
	      additionalLabels: {}
	
	kubecostMetrics.exporter.priorityClassName
	  ± type change from list to string
	    -
	    +
	
	kubecostModel
	  + four map entries added:
	    # The total number of weeks the ETL pipelines will build
	    # Set to 0 to disable weekly ETL (not recommended)
	    # The default is 53 to ensure at least a year of coverage (371 days)
	    etlWeeklyStoreDurationWeeks: 53
	    ## Feature to view your out-of-cluster costs and their k8s utilization
	    ## Ref: https://docs.kubecost.com/using-kubecost/navigating-the-kubecost-ui/cloud-costs-explorer
	    cloudCost:
	      enabled: true
	      labelList:
	        IsIncludeList: false
	        # format labels as comma separated string (ex. "label1,label2,label3")
	    labels: 
	      topNItems: 1000
	    allocation: 
	    livenessProbe:
	      enabled: false
	      initialDelaySeconds: 30
	      periodSeconds: 10
	      failureThreshold: 200
	    
	  
	
	ingress
	  + one map entry added:
	    # className: nginx
	    labels:
	
	podSecurityPolicy.enabled
	  ± value change
	    - true
	    + false
	
	persistentVolume
	  + two map entries added:
	    # storageClass: "-" #
	    # existingClaim: kubecost-cost-analyzer # a claim in the same namespace as kubecost
	    labels: {}
	    annotations: {}
	    
	  
	
	remoteWrite.postgres
	  + one map entry added:
	    ## PriorityClassName
	    ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
	    priorityClassName: 
	    
	  
	
	prometheus
	  + one map entry added:
	    podSecurityPolicy:
	      enabled: false
	
	prometheus.server.global.scrape_timeout
	  ± value change
	    - 10s
	    + 60s
	
	prometheus.serverFiles.rules.groups.CPU.rules
	  - five list entries removed:
	    - expr: sum(rate(container_cpu_usage_seconds_total{container_name!=""}[5m]))
	      record: "cluster:cpu_usage:rate5m"
	    - expr: rate(container_cpu_usage_seconds_total{container_name!=""}[5m])
	      record: "cluster:cpu_usage_nosum:rate5m"
	    - expr: "avg(irate(container_cpu_usage_seconds_total{container_name!="POD", container_name!=""}[5m])) by (container_name,pod_name,namespace)"
	      record: kubecost_container_cpu_usage_irate
	    - expr: "sum(container_memory_working_set_bytes{container_name!="POD",container_name!=""}) by (container_name,pod_name,namespace)"
	      record: kubecost_container_memory_working_set_bytes
	    - expr: "sum(container_memory_working_set_bytes{container_name!="POD",container_name!=""})"
	      record: kubecost_cluster_memory_working_set_bytes
	    
	  
	  + five list entries added:
	    - expr: sum(rate(container_cpu_usage_seconds_total{container!=""}[5m]))
	      record: "cluster:cpu_usage:rate5m"
	    - expr: rate(container_cpu_usage_seconds_total{container!=""}[5m])
	      record: "cluster:cpu_usage_nosum:rate5m"
	    - expr: "avg(irate(container_cpu_usage_seconds_total{container!="POD", container!=""}[5m])) by (container,pod,namespace)"
	      record: kubecost_container_cpu_usage_irate
	    - expr: "sum(container_memory_working_set_bytes{container!="POD",container!=""}) by (container,pod,namespace)"
	      record: kubecost_container_memory_working_set_bytes
	    - expr: "sum(container_memory_working_set_bytes{container!="POD",container!=""})"
	      record: kubecost_cluster_memory_working_set_bytes
	    
	  
	
	networkCosts
	  + two map entries added:
	    healthCheckProbes: {}
	    # readinessProbe:
	    #   tcpSocket:
	    #     port: 3001
	    #   initialDelaySeconds: 5
	    #   periodSeconds: 10
	    #   failureThreshold: 5
	    # livenessProbe:
	    #   tcpSocket:
	    #     port: 3001
	    #   initialDelaySeconds: 5
	    #   periodSeconds: 10
	    #   failureThreshold: 5
	    additionalSecurityContext: {}
	    # readOnlyRootFilesystem: true
	
	networkCosts.image
	  ± value change
	    - gcr.io/kubecost1/kubecost-network-costs:v16.2
	    + gcr.io/kubecost1/kubecost-network-costs:v0.16.8
	
	networkCosts.resources
	  + two map entries added:
	    limits:
	      cpu: 500m # can be less, will depend on cluster size
	    # memory: it is not recommended to set a memory limit
	    requests:
	      cpu: 50m
	      memory: 20Mi
	
	networkCosts.config.destinations
	  + one map entry added:
	    # Internet contains a list of address/range that will be
	    # classified as internet traffic. This is synonymous with traffic
	    # that cannot be classified within the cluster.
	    # NOTE: Internet classification filters are executed _after_
	    # NOTE: direct-classification, but before in-zone, in-region,
	    # NOTE: and cross-region.
	    internet: []
	
	networkCosts.service
	  + one map entry added:
	    labels: {}
	
	networkCosts.priorityClassName
	  ± type change from list to string
	    -
	    +
	
	kubecostDeployment
	  + four map entries added:
	    # deploymentStrategy:
	    #   rollingUpdate:
	    #     maxSurge: 1
	    #     maxUnavailable: 1
	    #   type: RollingUpdate
	    labels: {}
	    annotations: {}
	    ## QueryServiceReplicas
	    ## Ref: https://docs.kubecost.com/install-and-configure/advanced-configuration/query-service-replicas
	    ##
	    queryServiceReplicas: 0
	    queryService:
	      resources:
	        requests:
	          # You can use the Kubecost savings report for 'Right-size your container requests' to determine the recommended resource requests once the pod has run for 24 hours.
	    cpu: 1000m
	          memory: 500Mi
	      ## default storage class
	    storageClass: 
	      databaseVolumeSize: 100Gi
	      configVolumeSize: 1Gi
	    
	  
	
	clusterController
	  + three map entries added:
	    ## PriorityClassName
	    ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
	    priorityClassName: 
	    kubescaler:
	      # If true, will cause all (supported) workloads to be have their requests
	    # automatically right-sized on a regular basis.
	    defaultResizeAll: false
	    #  fqdn: kubecost-cluster-controller.kubecost.svc.cluster.local:9731
	    namespaceTurndown:
	      rbac:
	        enabled: true
	    
	  
	
	clusterController.image
	  ± value change
	    - gcr.io/kubecost1/cluster-controller:v0.1.0
	    + gcr.io/kubecost1/cluster-controller:v0.12.0
	
	serviceMonitor
	  + two map entries added:
	    metricRelabelings: []
	    relabelings: []
	
	serviceMonitor.networkCosts
	  + two map entries added:
	    metricRelabelings: []
	    relabelings: []
	
	grafana
	  - one map entry removed:
	    datasources:
	      datasources.yaml:
	        apiVersion: 1
	        datasources:
	        - name: prometheus-kubecost
	          url: "http://kubecost-prometheus-server.kubecost.svc.cluster.local"
	          type: prometheus
	          access: proxy
	          isDefault: false
	
	grafana.rbac.pspEnabled
	  ± value change
	    - true
	    + false
	
	grafana.grafana.ini.server
	  + one map entry added:
	    serve_from_sub_path: true
	
	awsstore
	  + one map entry added:
	    ## PriorityClassName
	    ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
	    priorityClassName: 
	    
	  
	
	federatedETL
	  + one map entry added:
	    useMultiClusterDB: false # set to true if you have a single federated PromQL DB with metrics from all monitored clusters but want to use federation for performance
	    
	  
	
	federatedETL.federator
	  + one map entry added:
	    # primaryClusterID: "cluster_id" # optional. Used when reconciliation is expected to occur on the Primary.
	    # federationCutoffDate: "2022-10-18T00:00:00.000Z" # an RFC 3339-formatted string. All ETL files with windows that fall before this time are not processed by the Federator. If this is not set, the Federator will process all files regardless of date.
	    resources: {}
	    # requests:
	    #   cpu: 100m
	    #   memory: 500Mi
	    
	  